### PR TITLE
CAT-679 Flag PF cases to security

### DIFF
--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/RiskProfilerApi.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/RiskProfilerApi.groovy
@@ -11,6 +11,11 @@ class RiskProfilerApi extends WireMockRule {
     super(8082)
   }
 
+  void stubForTasklists(String offenderno, String category, boolean transferToSecurity = false, boolean increasedRisk = false, boolean notifyRegionalCTLead = false) {
+    stubGetSocProfile(offenderno, category, transferToSecurity)
+    stubGetExtremismProfile(offenderno, category, increasedRisk, notifyRegionalCTLead)
+  }
+
   void stubGetSocProfile(String offenderno, String category, boolean transferToSecurity) {
     this.stubFor(
       get("/risk-profile/soc/${offenderno}")

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/model/TestFixture.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/model/TestFixture.groovy
@@ -111,7 +111,7 @@ class TestFixture {
     loginAs(CATEGORISER_USER)
     browser.at CategoriserHomePage
     elite2Api.stubGetOffenderDetails(12, 'B2345YZ', false,  false, 'C', multipleSentences)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', transferToSecurity)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', transferToSecurity)
     browser.selectSecondPrisoner()
   }
 
@@ -121,7 +121,7 @@ class TestFixture {
     loginAs(RECATEGORISER_USER)
     browser.at RecategoriserHomePage
     elite2Api.stubGetOffenderDetails(12, 'B2345YZ', false, indeterminateSentence)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', transferToSecurity)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', transferToSecurity)
     browser.selectFirstPrisoner()
   }
 
@@ -131,17 +131,7 @@ class TestFixture {
     loginAs(RECATEGORISER_USER)
     browser.at RecategoriserHomePage
     elite2Api.stubGetOffenderDetails(21, 'C0001AA', true, false, 'I')
-    riskProfilerApi.stubGetSocProfile('C0001AA', 'I', transferToSecurity)
-    browser.selectFirstPrisoner()
-  }
-
-  def gotoTasklistRecatForCatIIndeterminate(transferToSecurity = false) {
-    elite2Api.stubRecategoriseWithCatI()
-
-    loginAs(RECATEGORISER_USER)
-    browser.at RecategoriserHomePage
-    elite2Api.stubGetOffenderDetails(21, 'C0001AA', true, true, 'I')
-    riskProfilerApi.stubGetSocProfile('C0001AA', 'C', transferToSecurity)
+    riskProfilerApi.stubForTasklists('C0001AA', 'I', transferToSecurity)
     browser.selectFirstPrisoner()
   }
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/model/TestFixture.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/model/TestFixture.groovy
@@ -135,6 +135,16 @@ class TestFixture {
     browser.selectFirstPrisoner()
   }
 
+  def gotoTasklistRecatForCatIIndeterminate(transferToSecurity = false) {
+    elite2Api.stubRecategoriseWithCatI()
+
+    loginAs(RECATEGORISER_USER)
+    browser.at RecategoriserHomePage
+    elite2Api.stubGetOffenderDetails(21, 'C0001AA', true, true, 'I')
+    riskProfilerApi.stubForTasklists('C0001AA', 'C', transferToSecurity)
+    browser.selectFirstPrisoner()
+  }
+
   def simulateLogin() {
     browser.waitFor { browser.$('h1').text() == 'Sign in' }
     def requests = oauthApi.getAllServeEvents()

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/recat/RiskProfileChangeDetailPage.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/recat/RiskProfileChangeDetailPage.groovy
@@ -22,8 +22,6 @@ class RiskProfileChangeDetailPage extends Page {
     escapeWarning {$('#escapeWarning')}
     escapeAlerts {$('#escapeAlerts')}
     escapeAlertsOld {$('#escapeAlertsOld')}
-    extremismNotifyWarning {$('#notifyCtExtremismWarning')}
-    increasedRiskExtremismWarning {$('#increasedRiskExtremismWarning')}
     violenceWarningOld {$('#violenceWarningOld')}
     violenceWarningNew {$('#violenceWarningNew')}
     violenceNotifyWarning {$('#notifyCTViolenceWarning')}

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/HomePageSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/HomePageSpecification.groovy
@@ -200,7 +200,7 @@ class HomePageSpecification extends GebReportingSpec {
     fixture.loginAs(CATEGORISER_USER)
     at CategoriserHomePage
     elite2Api.stubGetOffenderDetails(678, "ON678")
-    riskProfilerApi.stubGetSocProfile('ON678', 'C', false)
+    riskProfilerApi.stubForTasklists('ON678', 'C', false)
     startButtons[0].click() // selects B2345YZ
     at(new TasklistPage(bookingId: '678'))
     headerValue*.text() == ['Hillmob, Ant', 'ON678', '17/02/1970', 'C-04-02', 'Coventry', 'A Felony', 'Another Felony', 'Latvian', '02/02/2020']

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/LandingPageSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/LandingPageSpecification.groovy
@@ -55,7 +55,7 @@ class LandingPageSpecification extends GebReportingSpec {
     recatButton.displayed
 
     when: 'It is clicked'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     elite2Api.stubUpdateNextReviewDate(LocalDate.now().plusDays(fixture.get10BusinessDays()).format('yyyy-MM-dd'))
     recatButton.click()
 
@@ -134,7 +134,7 @@ class LandingPageSpecification extends GebReportingSpec {
     !warning.displayed
 
     when: 'It is clicked'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     elite2Api.stubUpdateNextReviewDate(LocalDate.now().plusDays(fixture.get10BusinessDays()).format('yyyy-MM-dd'))
     editButton.click()
 
@@ -227,7 +227,7 @@ class LandingPageSpecification extends GebReportingSpec {
     at LandingPage
     elite2Api.stubUpdateNextReviewDate(LocalDate.now().plusDays(fixture.get10BusinessDays()).format('yyyy-MM-dd'))
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     recatButton.click()
 
     then: 'Security is locked'
@@ -306,7 +306,7 @@ class LandingPageSpecification extends GebReportingSpec {
     go '/12'
     at LandingPage
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', true)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', true)
     elite2Api.stubUpdateNextReviewDate(LocalDate.now().plusDays(fixture.get10BusinessDays()).format('yyyy-MM-dd'))
     recatButton.click()
 
@@ -391,7 +391,7 @@ class LandingPageSpecification extends GebReportingSpec {
     !warning.displayed
 
     when: 'It is clicked'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     elite2Api.stubSetInactive(12, 'ACTIVE')
     initialButton.click()
 
@@ -423,7 +423,7 @@ class LandingPageSpecification extends GebReportingSpec {
     warning.text() endsWith 'This prisoner already has a category of Cat B.'
 
     when: 'It is clicked'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     elite2Api.stubSetInactive(12, 'ACTIVE')
     initialButton.click()
 
@@ -457,7 +457,7 @@ class LandingPageSpecification extends GebReportingSpec {
     !warning.displayed
 
     when: 'It is clicked'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     elite2Api.stubSetInactive(12, 'ACTIVE')
     editButton.click()
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/LiteSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/LiteSpecification.groovy
@@ -143,7 +143,7 @@ class LiteSpecification extends GebReportingSpec {
 
     then: 'The correct error is shown'
     at ErrorPage
-    errorSummaryTitle.text() == 'Error: There is an unapproved categorisation in the "other categories" section'
+    errorSummaryTitle.text() == 'Error: This prisoner has an unapproved categorisation in the "Other categories" section'
 
     when: 'I go to the initial todo list'
     fixture.logout()
@@ -158,7 +158,7 @@ class LiteSpecification extends GebReportingSpec {
 
     then: 'The correct error is shown'
     at ErrorPage
-    errorSummaryTitle.text() == 'Error: There is an unapproved categorisation in the "other categories" section'
+    errorSummaryTitle.text() == 'Error: This prisoner has an unapproved categorisation in the "Other categories" section'
 
     ///////////////////////////////////////////////////////////////////////////////////////
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/OpenConditionsSpecification.groovy
@@ -81,7 +81,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     overriddenCategoryD.click()
     overriddenCategoryText << 'categoriser override to D comment'
     otherInformationText << 'categoriser relevant info 1'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
     at OpenConditionsAddedPage
     button.click()
@@ -269,7 +269,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     def date12 = LocalDate.now().plusDays(-1).toString()
     elite2Api.stubSentenceData(['B2345XY', 'B2345YZ'], [11, 12], [date11, date12])
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     stillReferNo.click()
     submitButton.click()
 
@@ -334,7 +334,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     assert !indeterminateWarning.displayed
     overriddenCategoryText << 'categoriser override to D comment'
     otherInformationText << 'categoriser relevant info 1'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
     at OpenConditionsAddedPage
     button.click()
@@ -482,7 +482,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     overriddenCategoryD.click()
     overriddenCategoryText << 'categoriser override to D comment'
     otherInformationText << 'categoriser relevant info 1'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
     at OpenConditionsAddedPage
     button.click()
@@ -587,7 +587,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     appropriateYes.click()
     otherInformationText << 'categoriser relevant info for accept'
     elite2Api.stubCategorise('C', '2019-12-14', 12, 5)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
 
     then: 'the cat C is submitted'
@@ -736,7 +736,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     def date12 = LocalDate.now().plusDays(-1).toString()
     elite2Api.stubSentenceData(['B2345XY', 'B2345YZ'], [11, 12], [date11, date12])
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
   }
 }

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ProvisionalCategorySpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ProvisionalCategorySpecification.groovy
@@ -186,7 +186,7 @@ class ProvisionalCategorySpecification extends GebReportingSpec {
     when: 'Changing to Cat J'
     overriddenCategoryText << "Some Text"
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
     at OpenConditionsAddedPage
     button.click()
@@ -226,7 +226,7 @@ class ProvisionalCategorySpecification extends GebReportingSpec {
     otherInformationText << TRICKY_TEXT
     overriddenCategoryD.click()
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
     at OpenConditionsAddedPage
     button.click()
@@ -370,7 +370,7 @@ class ProvisionalCategorySpecification extends GebReportingSpec {
     warning[0].text() == 'D\nWarning\nBased on the information provided, the provisional category is D'
 
     when: 'I reject Cat D'
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     appropriateNo.click()
     submitButton.click()
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ReviewSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ReviewSpecification.groovy
@@ -67,7 +67,7 @@ class ReviewSpecification extends GebReportingSpec {
     fixture.loginAs(CATEGORISER_USER)
     at CategoriserHomePage
     elite2Api.stubGetOffenderDetails(12, 'B2345YZ', false,  false, 'C', false)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     selectFirstPrisoner() // has been sorted to top of list!
     at(new TasklistPage(bookingId: '12'))
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/SupervisorSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/SupervisorSpecification.groovy
@@ -261,7 +261,7 @@ class SupervisorSpecification extends GebReportingSpec {
     fixture.loginAs(CATEGORISER_USER)
     at CategoriserHomePage
     elite2Api.stubGetOffenderDetails(12, 'B2345YZ', false,  false, 'C', false)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     selectFirstPrisoner() // has been sorted to top of list!
     at TasklistPage
     supervisorMessageButton.click()

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/TasklistRecatSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/TasklistRecatSpecification.groovy
@@ -58,7 +58,9 @@ class TasklistRecatSpecification extends GebReportingSpec {
     and: 'SOC data is stored and merged correctly'
     def data = db.getData(12)
     def response = new JsonSlurper().parseText(data.risk_profile[0].toString())
-    response == [socProfile: [nomsId: "B2345YZ", riskType: "SOC", transferToSecurity: false, provisionalCategorisation: 'C']]
+    response == [socProfile      : [nomsId: "B2345YZ", riskType: "SOC", transferToSecurity: false, provisionalCategorisation: 'C'],
+                 extremismProfile: [nomsId: 'B2345YZ', riskType: 'EXTREMISM', notifyRegionalCTLead: false, increasedRiskOfExtremism: false, provisionalCategorisation: 'C']
+    ]
     def row = data[0]
     row.booking_id == 12L
     row.user_id == "RECATEGORISER_USER"
@@ -87,7 +89,9 @@ class TasklistRecatSpecification extends GebReportingSpec {
     and: 'data is stored correctly'
     def data = db.getData(21)
     def response = new JsonSlurper().parseText(data.risk_profile[0].toString())
-    response == [socProfile: [nomsId: "C0001AA", riskType: "SOC", transferToSecurity: false, provisionalCategorisation: 'I']]
+    response == [socProfile      : [nomsId: 'C0001AA', riskType: 'SOC', transferToSecurity: false, provisionalCategorisation: 'I'],
+                 extremismProfile: [nomsId: 'C0001AA', riskType: 'EXTREMISM', notifyRegionalCTLead: false, increasedRiskOfExtremism: false, provisionalCategorisation: 'I']
+    ]
     def row = data[0]
     row.booking_id == 21L
     row.offender_no == "C0001AA"
@@ -151,7 +155,7 @@ class TasklistRecatSpecification extends GebReportingSpec {
     fixture.loginAs(RECATEGORISER_USER)
     browser.at RecategoriserHomePage
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     // TODO: was not in the to-do list so have to go directly, BUT NOW IS with wrong button label 'edit'
     to TasklistRecatPage, '12', reason: 'DUE'
 
@@ -186,7 +190,7 @@ class TasklistRecatSpecification extends GebReportingSpec {
     fixture.loginAs(RECATEGORISER_USER)
     browser.at RecategoriserHomePage
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     via TasklistRecatPage, '12'
 
     then: 'The correct error is displayed'

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/TasklistSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/TasklistSpecification.groovy
@@ -57,8 +57,9 @@ class TasklistSpecification extends GebReportingSpec {
     def data = db.getData(12)
     data.status == ["STARTED"]
     def response = new JsonSlurper().parseText(data.risk_profile[0].toString())
-    response == [socProfile   : [nomsId: "B2345YZ", riskType: "SOC", transferToSecurity: false, provisionalCategorisation: 'C'],
-                 escapeProfile: [nomsId: "Dummy"]]
+    response == [socProfile      : [nomsId: "B2345YZ", riskType: "SOC", transferToSecurity: false, provisionalCategorisation: 'C'],
+                 extremismProfile: [nomsId: 'B2345YZ', riskType: 'EXTREMISM', notifyRegionalCTLead: false, increasedRiskOfExtremism: false, provisionalCategorisation: 'C'],
+                 escapeProfile   : [nomsId: "Dummy"]]
   }
 
   def "The continue button behaves correctly"() {

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ratings/SecurityInputSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/ratings/SecurityInputSpecification.groovy
@@ -50,7 +50,7 @@ class SecurityInputSpecification extends GebReportingSpec {
 
     elite2Api.stubAssessments(['B2345YZ'])
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
 
     securityButton.click()
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
@@ -609,7 +609,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     commentLabel.size() == 1
   }
 
-  def completeOpenConditionsWorkflow() {
+  private completeOpenConditionsWorkflow() {
     openConditionsButton.click()
     at EarliestReleasePage
     threeOrMoreYearsNo.click()
@@ -630,7 +630,7 @@ class OpenConditionsSpecification extends GebReportingSpec {
     def date12 = LocalDate.now().plusDays(-1).toString()
     elite2Api.stubSentenceData(['B2345XY', 'B2345YZ'], [11, 12], [date11, date12])
     elite2Api.stubGetOffenderDetails(12)
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
     submitButton.click()
   }
 }

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/RiskChangeAlertDetailSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/RiskChangeAlertDetailSpecification.groovy
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.cattool.specs.recat
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer
 import geb.spock.GebReportingSpec
+import groovy.json.JsonOutput
 import org.junit.Rule
 import uk.gov.justice.digital.hmpps.cattool.mockapis.Elite2Api
 import uk.gov.justice.digital.hmpps.cattool.mockapis.OauthApi
@@ -54,14 +55,12 @@ class RiskChangeAlertDetailSpecification extends GebReportingSpec {
     escapeWarning.isDisplayed()
     escapeAlerts.isDisplayed()
     escapeAlertsOld.isDisplayed()
-    extremismNotifyWarning.isDisplayed()
-    increasedRiskExtremismWarning.isDisplayed()
 
     when: 'I select yes to process'
     elite2Api.stubUpdateNextReviewDate(LocalDate.now().plusDays(fixture.get10BusinessDays()).format('yyyy-MM-dd'))
 
     elite2Api.stubGetOffenderDetails(12, 'B2345XY')
-    riskProfilerApi.stubGetSocProfile('B2345XY', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345XY', 'C', false)
     answerYes.click()
     submitButton.click()
 
@@ -70,7 +69,6 @@ class RiskChangeAlertDetailSpecification extends GebReportingSpec {
 
     def data = db.getRiskChange('B2345XY')
     data.status == ["REVIEW_REQUIRED"]
-
   }
 
   def "The risk change alert can be ignored"() {
@@ -95,11 +93,17 @@ class RiskChangeAlertDetailSpecification extends GebReportingSpec {
   }
 
   void gotoRiskChangeDetail() {
-   /* db.createDataWithStatusAndCatType(12, 'APPROVED', JsonOutput.toJson([
-      ratings: TestFixture.defaultRatingsC]), 'INITIAL') */
+    /* db.createDataWithStatusAndCatType(12, 'APPROVED', JsonOutput.toJson([
+       ratings: TestFixture.defaultRatingsC]), 'INITIAL') */
     def raisedDate = LocalDate.of(2019, 1, 31)
-    def oldProfile = '{"soc": {"nomsId": "B2345XY", "riskType": "SOC", "transferToSecurity": false, "provisionalCategorisation": "C"}, "escape": {"nomsId": "G5021GJ", "riskType": "ESCAPE", "activeEscapeList": false, "activeEscapeRisk": false, "escapeListAlerts": [], "escapeRiskAlerts": [], "provisionalCategorisation": "C"}, "violence": {"nomsId": "G5021GJ", "riskType": "VIOLENCE", "displayAssaults": true, "numberOfAssaults": 10, "notifySafetyCustodyLead": false, "numberOfSeriousAssaults": 0, "provisionalCategorisation": "C", "veryHighRiskViolentOffender": false}, "extremism": {"nomsId": "G5021GJ", "riskType": "EXTREMISM", "notifyRegionalCTLead": false, "increasedRiskOfExtremism": false, "provisionalCategorisation": "C"}}'
-    def newProfile = '{"soc": {"nomsId": "B2345XY", "riskType": "SOC", "transferToSecurity": true, "provisionalCategorisation": "C"}, "escape": {"nomsId": "G5021GJ", "riskType": "ESCAPE", "activeEscapeList": false, "activeEscapeRisk": true, "escapeListAlerts": [], "escapeRiskAlerts": [{"active": true, "alertId": 23, "comment": "WozkLbgfVNNRkjsYGmLfWozkLbgfVNNRkjsYGmLf", "expired": false, "ranking": 0, "alertCode": "XER", "alertType": "X", "bookingId": 869603, "offenderNo": "G5021GJ", "dateCreated": "2016-08-15", "alertCodeDescription": "Escape Risk", "alertTypeDescription": "Security"}], "provisionalCategorisation": "C"}, "violence": {"nomsId": "G5021GJ", "riskType": "VIOLENCE", "displayAssaults": true, "numberOfAssaults": 10, "notifySafetyCustodyLead": true, "numberOfSeriousAssaults": 1, "provisionalCategorisation": "B", "veryHighRiskViolentOffender": false}, "extremism": {"nomsId": "G5021GJ", "riskType": "EXTREMISM", "notifyRegionalCTLead": true, "increasedRiskOfExtremism": true, "provisionalCategorisation": "C"}}'
+    def oldProfile = JsonOutput.toJson([
+      "soc": ["nomsId": "B2345XY", "riskType": "SOC", "transferToSecurity": false, "provisionalCategorisation": "C"],
+      "escape": ["nomsId": "G5021GJ", "riskType": "ESCAPE", "activeEscapeList": false, "activeEscapeRisk": false, "escapeListAlerts": [], "escapeRiskAlerts": [], "provisionalCategorisation": "C"],
+      "violence": ["nomsId": "G5021GJ", "riskType": "VIOLENCE", "displayAssaults": true, "numberOfAssaults": 10, "notifySafetyCustodyLead": false, "numberOfSeriousAssaults": 0, "provisionalCategorisation": "C", "veryHighRiskViolentOffender": false]])
+    def newProfile = JsonOutput.toJson([
+      "soc": ["nomsId": "B2345XY", "riskType": "SOC", "transferToSecurity": true, "provisionalCategorisation": "C"],
+      "escape": ["nomsId": "G5021GJ", "riskType": "ESCAPE", "activeEscapeList": false, "activeEscapeRisk": true, "escapeListAlerts": [], "escapeRiskAlerts": [["active": true, "alertId": 23, "comment": "text", "expired": false, "ranking": 0, "alertCode": "XER", "alertType": "X", "bookingId": 869603, "offenderNo": "G5021GJ", "dateCreated": "2016-08-15", "alertCodeDescription": "Escape Risk", "alertTypeDescription": "Security"]], "provisionalCategorisation": "C"],
+      "violence": ["nomsId": "G5021GJ", "riskType": "VIOLENCE", "displayAssaults": true, "numberOfAssaults": 10, "notifySafetyCustodyLead": true, "numberOfSeriousAssaults": 1, "provisionalCategorisation": "B", "veryHighRiskViolentOffender": false]])
 
     db.createRiskChange(-1, 'B2345XY', null, 'NEW',
       oldProfile,

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/SecurityInputSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/SecurityInputSpecification.groovy
@@ -48,7 +48,7 @@ class SecurityInputSpecification extends GebReportingSpec {
 
     elite2Api.stubAssessments(['B2345YZ'])
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
 
     securityButton.click()
 
@@ -76,7 +76,7 @@ class SecurityInputSpecification extends GebReportingSpec {
 
     elite2Api.stubAssessments(['B2345YZ'])
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
-    riskProfilerApi.stubGetSocProfile('B2345YZ', 'C', false)
+    riskProfilerApi.stubForTasklists('B2345YZ', 'C', false)
 
     when: 'The user refers to security'
     securityButton.click()

--- a/server/routes/tasklist.js
+++ b/server/routes/tasklist.js
@@ -60,7 +60,7 @@ module.exports = function Index({
       if (liteInProgress) {
         await transactionalDbClient.query('ROLLBACK')
         return res.render('pages/error', {
-          message: 'Error: There is an unapproved categorisation in the "other categories" section',
+          message: 'Error: This prisoner has an unapproved categorisation in the "Other categories" section',
           backLink,
         })
       }

--- a/server/routes/tasklistRecat.js
+++ b/server/routes/tasklistRecat.js
@@ -76,7 +76,7 @@ module.exports = function Index({
       if (liteInProgress) {
         await transactionalDbClient.query('ROLLBACK')
         return res.render('pages/error', {
-          message: 'Error: There is an unapproved categorisation in the "other categories" section',
+          message: 'Error: This prisoner has an unapproved categorisation in the "Other categories" section',
           backLink,
         })
       }

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -487,8 +487,18 @@ module.exports = function createFormService(formClient) {
     }
   }
 
-  async function referToSecurityIfRiskAssessed(bookingId, userId, socProfile, currentStatus, transactionalClient) {
-    if (socProfile.transferToSecurity && currentStatus !== Status.SECURITY_BACK.name) {
+  async function referToSecurityIfRiskAssessed(
+    bookingId,
+    userId,
+    socProfile,
+    extremismProfile,
+    currentStatus,
+    transactionalClient
+  ) {
+    if (
+      (socProfile.transferToSecurity || extremismProfile.notifyRegionalCTLead) &&
+      currentStatus !== Status.SECURITY_BACK.name
+    ) {
       if (validateStatusIfProvided(currentStatus, Status.SECURITY_AUTO.name)) {
         await formClient.referToSecurity(bookingId, null, Status.SECURITY_AUTO.name, transactionalClient)
         return Status.SECURITY_AUTO.name

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -700,14 +700,13 @@ module.exports = function createOffendersService(nomisClientBuilder, formService
         return []
       }
 
-      const decoratedReviewAndU21 = mergeOffenderListsRemovingNulls(decoratedResultsU21, decoratedResultsReview) // ignore initial cats (which were set to null)
+      return mergeOffenderListsRemovingNulls(decoratedResultsU21, decoratedResultsReview) // ignore initial cats (which were set to null)
         .sort((a, b) => {
           const status = sortByStatus(b.dbStatus, a.dbStatus)
           return status === 0 ? sortByDateTime(b.nextReviewDateDisplay, a.nextReviewDateDisplay) : status
         })
-      return decoratedReviewAndU21
     } catch (error) {
-      logger.error(error, 'Error during getRecategorisedOffenders')
+      logger.error(error, 'Error during getRecategoriseOffenders')
       throw error
     }
   }

--- a/server/utils/functionalHelpers.js
+++ b/server/utils/functionalHelpers.js
@@ -91,13 +91,19 @@ async function addSocProfile({
   // only load the soc profile once - then it is saved against the record
   if (isFirstVisit(res)) {
     const socProfile = await riskProfilerService.getSecurityProfile(details.offenderNo, res.locals)
+    const extremismProfile = await riskProfilerService.getExtremismProfile(
+      details.offenderNo,
+      res.locals,
+      false // don't yet have the answer to this question - will be populated correctly in the review route
+    )
 
-    await formService.mergeRiskProfileData(bookingId, { socProfile }, transactionalDbClient)
+    await formService.mergeRiskProfileData(bookingId, { socProfile, extremismProfile }, transactionalDbClient)
 
     status = await formService.referToSecurityIfRiskAssessed(
       bookingId,
       req.user.username,
       socProfile,
+      extremismProfile,
       status,
       transactionalDbClient
     )

--- a/server/utils/riskChange.js
+++ b/server/utils/riskChange.js
@@ -30,18 +30,6 @@ function isNewlyReferredToSecurity(oldP, newP) {
   return !oldRisk && newRisk
 }
 
-function nowRequiresNotifyRegionalCTLead(oldP, newP) {
-  const oldNotify = oldP.extremism.notifyRegionalCTLead
-  const newNotify = newP.extremism.notifyRegionalCTLead
-  return !oldNotify && newNotify
-}
-
-function isIncreasedRiskOfExtremism(oldP, newP) {
-  const oldNotify = oldP.extremism.increasedRiskOfExtremism
-  const newNotify = newP.extremism.increasedRiskOfExtremism
-  return !oldNotify && newNotify
-}
-
 function changeInViolenceCategoryRecommendation(oldP, newP) {
   const oldCategory = oldP.violence.provisionalCategorisation
   const newCategory = newP.violence.provisionalCategorisation
@@ -53,8 +41,6 @@ const assessRiskProfiles = (oldP, newP) => {
   const escapeRiskAlert = riskAlertChange(oldP, newP)
   const escapeList = isNewlyOnTheEscapeList(oldP, newP)
   const escapeRisk = isNewEscapeRisk(oldP, newP)
-  const increasedRiskOfExtremism = isIncreasedRiskOfExtremism(oldP, newP)
-  const notifyRegionalCTLeadExtremism = nowRequiresNotifyRegionalCTLead(oldP, newP)
   const violenceChange = changeInViolenceCategoryRecommendation(oldP, newP)
   const socNewlyReferred = isNewlyReferredToSecurity(oldP, newP)
   return {
@@ -62,19 +48,9 @@ const assessRiskProfiles = (oldP, newP) => {
     escapeRiskAlert,
     escapeList,
     escapeRisk,
-    increasedRiskOfExtremism,
-    notifyRegionalCTLeadExtremism,
     violenceChange,
     socNewlyReferred,
-    alertRequired:
-      escapeListAlert ||
-      escapeRiskAlert ||
-      escapeRisk ||
-      escapeList ||
-      increasedRiskOfExtremism ||
-      notifyRegionalCTLeadExtremism ||
-      violenceChange ||
-      socNewlyReferred,
+    alertRequired: escapeListAlert || escapeRiskAlert || escapeRisk || escapeList || violenceChange || socNewlyReferred,
   }
 }
 

--- a/server/views/formPages/recat/riskProfileChangeDetail.html
+++ b/server/views/formPages/recat/riskProfileChangeDetail.html
@@ -69,41 +69,12 @@ attributes: {  'id': 'escapeWarning'},
 
 {% endif %}
 
-{% if data.increasedRiskOfExtremism or data.notifyRegionalCTLeadExtremism %}
-<h2 id="extremismSection" class="govuk-heading-m  govuk-!-padding-top-4">Extremism</h2>
-
-{% if data.increasedRiskOfExtremism %}
- {{ govukWarningText({
-      text: "This person is now at risk, or vulnerable to, extremism",
-      iconFallbackText: "Warning",
-      attributes: {  'id': 'increasedRiskExtremismWarning'},
-      classes: "forms-warning-text warning-overrides"
-    }) }}
-{% endif %}
-
-{% if data.notifyRegionalCTLeadExtremism %}
- {{ govukWarningText({
-      text: 'Notify your regional CT leader that you have this person in custody',
-      iconFallbackText: "Warning",
-      attributes: {  'id': 'notifyCtExtremismWarning'},
-      classes: "forms-warning-text warning-overrides"
-    }) }}
-{% endif %}
-
-{% endif %}
-
 {% if data.violenceChange %}
 <h2 id="violenceSection" class="govuk-heading-m  govuk-!-padding-top-4">Safety and good order</h2>
 
-     {% set totalNewAssaults =  (data.newProfile.violence.numberOfSeriousAssaults + data.newProfile.violence.numberOfAssaults)%}
     {% set warningText %}
-      They have been reported as the perpetrator of {{ totalNewAssaults }} assaults in total during this sentence
-      <br/>
-      {% if data.newProfile.violence.numberOfSeriousAssaults == 1 %}
-      Of these, 1 was a serious assault committed in the past 12 months
-      {% else %}
-      Of these, {{ data.newProfile.violence.numberOfSeriousAssaults }} were serious assaults committed in the past 12 months
-      {% endif %}
+      They have been reported as the perpetrator of {{ data.newProfile.violence.numberOfAssaults }} assaults in custody before,
+      including {{ data.newProfile.violence.numberOfSeriousAssaults }} serious assaults and {{ data.newProfile.violence.numberOfNonSeriousAssaults }} non-serious assaults in the past 12 months
     {% endset %}
     {{ govukWarningText({
       html: warningText,
@@ -126,18 +97,12 @@ attributes: {  'id': 'escapeWarning'},
     </span>
   </summary>
   <div class="govuk-details__text">
-    {% set totalOldAssaults =  (data.oldProfile.violence.numberOfSeriousAssaults + data.oldProfile.violence.numberOfAssaults)%}
     {% set warningText %}
-    {% if totalOldAssaults == 0 %}
+    {% if data.oldProfile.violence.numberOfAssaults == 0 %}
       There are no reported assaults during this sentence
     {% else %}
-      They have been reported as the perpetrator of {{ totalOldAssaults }} assaults in total during this sentence
-      <br/>
-      {% if data.oldProfile.violence.numberOfSeriousAssaults == 1 %}
-      Of these, 1 was a serious assault committed in the past 12 months
-      {% else %}
-      Of these, {{ data.oldProfile.violence.numberOfSeriousAssaults }} were serious assaults committed in the past 12 months
-      {% endif %}
+      They have been reported as the perpetrator of {{ data.oldProfile.violence.numberOfAssaults }} assaults in custody before,
+      including {{ data.oldProfile.violence.numberOfSeriousAssaults }} serious assaults and {{ data.oldProfile.violence.numberOfNonSeriousAssaults }} non-serious assaults in the past 12 months
     {% endif %}
     {% endset %}
     {{ govukWarningText({

--- a/test/routes/form.test.js
+++ b/test/routes/form.test.js
@@ -652,8 +652,8 @@ describe('GET /ratings/violence', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toMatch(/Home.+Categorisation home.+Safety and good order/s)
-        expect(res.text).toContain('This person has been reported as the perpetrator in 5 assaults in custody before,')
-        expect(res.text).toContain('including 2 serious assaults and 3 non-serious assaults in the past 12 months.')
+        expect(res.text).toContain(`This person has been reported as the perpetrator in 5 assaults in custody before,
+      including 2 serious assaults and 3 non-serious assaults in the past 12 months.`)
         expect(res.text).toContain('Please notify your safer custody lead about this prisoner')
       })
   })

--- a/test/routes/recat.test.js
+++ b/test/routes/recat.test.js
@@ -260,8 +260,8 @@ describe('recat', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('This person has been reported as the perpetrator in 5 assaults in custody before,')
-        expect(res.text).toContain('including 2 serious assaults and 4 non-serious assaults in the past 12 months.')
+        expect(res.text).toContain(`This person has been reported as the perpetrator in 5 assaults in custody before,
+      including 2 serious assaults and 4 non-serious assaults in the past 12 months.`)
         expect(res.text).toMatch(/Home.+Categorisation home.+Category review task list.+Check your answers/s)
       })
   })
@@ -368,10 +368,16 @@ describe('GET /riskProfileChangeDetail/:bookingId', () => {
     offendersService.getRiskChangeForOffender.mockResolvedValue({
       socNewlyReferred: true,
       escapeList: true,
-      notifyRegionalCTLeadExtremism: true,
       violenceChange: true,
       bookingId: 12345,
-      newProfile: { violence: { numberOfSeriousAssaults: 1, numberOfAssaults: 0, provisionalCategorisation: 'C' } },
+      newProfile: {
+        violence: {
+          numberOfSeriousAssaults: 1,
+          numberOfNonSeriousAssaults: 2,
+          numberOfAssaults: 4,
+          provisionalCategorisation: 'C',
+        },
+      },
       oldProfile: { violence: { numberOfSeriousAssaults: 0, numberOfAssaults: 0, provisionalCategorisation: 'B' } },
     })
     return request(app)
@@ -384,12 +390,11 @@ describe('GET /riskProfileChangeDetail/:bookingId', () => {
           'This person needs to be considered by security. Please start a review and refer this person to security.'
         )
         expect(res.text).toContain('Notify your safer custody lead about this prisoner')
-        expect(res.text).toContain('Notify your regional CT leader that you have this person in custody')
         expect(res.text).toContain('This person is now considered a risk of escape')
         expect(res.text).toContain(
-          'They have been reported as the perpetrator of 1 assaults in total during this sentence'
+          `They have been reported as the perpetrator of 4 assaults in custody before,
+      including 1 serious assaults and 2 non-serious assaults in the past 12 months`
         )
-        expect(res.text).toContain('Of these, 1 was a serious assault committed in the past 12 months')
         expect(res.text).toContain('There are no reported assaults during this sentence')
         expect(res.text).toContain('Do you want to start an early category review?')
       })
@@ -399,51 +404,24 @@ describe('GET /riskProfileChangeDetail/:bookingId', () => {
     offendersService.getRiskChangeForOffender.mockResolvedValue({
       violenceChange: true,
       bookingId: 12345,
-      newProfile: { violence: { numberOfSeriousAssaults: 3, numberOfAssaults: 1 } },
-      oldProfile: { violence: { numberOfSeriousAssaults: 0, numberOfAssaults: 1 } },
+      newProfile: { violence: { numberOfSeriousAssaults: 3, numberOfNonSeriousAssaults: 2, numberOfAssaults: 7 } },
+      oldProfile: { violence: { numberOfSeriousAssaults: 0, numberOfNonSeriousAssaults: 5, numberOfAssaults: 6 } },
     })
     return request(app)
       .get(`/riskProfileChangeDetail/12345`)
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).not.toContain('Extremism')
         expect(res.text).not.toContain('Risk of escape')
         expect(res.text).not.toContain('Security referral')
         expect(res.text).toContain(
-          'They have been reported as the perpetrator of 4 assaults in total during this sentence'
+          `They have been reported as the perpetrator of 7 assaults in custody before,
+      including 3 serious assaults and 2 non-serious assaults in the past 12 months`
         )
         expect(res.text).toContain(
-          'They have been reported as the perpetrator of 1 assaults in total during this sentence'
+          `They have been reported as the perpetrator of 6 assaults in custody before,
+      including 0 serious assaults and 5 non-serious assaults in the past 12 months`
         )
-        expect(res.text).toContain('Of these, 3 were serious assaults committed in the past 12 months')
-        expect(res.text).toContain('Of these, 0 were serious assaults committed in the past 12 months')
-      })
-  })
-
-  test('Assaults wording', () => {
-    offendersService.getRiskChangeForOffender.mockResolvedValue({
-      violenceChange: true,
-      bookingId: 12345,
-      newProfile: { violence: { numberOfSeriousAssaults: 3, numberOfAssaults: 1 } },
-      oldProfile: { violence: { numberOfSeriousAssaults: 0, numberOfAssaults: 1 } },
-    })
-    return request(app)
-      .get(`/riskProfileChangeDetail/12345`)
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).not.toContain('Extremism')
-        expect(res.text).not.toContain('Risk of escape')
-        expect(res.text).not.toContain('Security referral')
-        expect(res.text).toContain(
-          'They have been reported as the perpetrator of 4 assaults in total during this sentence'
-        )
-        expect(res.text).toContain(
-          'They have been reported as the perpetrator of 1 assaults in total during this sentence'
-        )
-        expect(res.text).toContain('Of these, 3 were serious assaults committed in the past 12 months')
-        expect(res.text).toContain('Of these, 0 were serious assaults committed in the past 12 months')
       })
   })
 
@@ -451,31 +429,30 @@ describe('GET /riskProfileChangeDetail/:bookingId', () => {
     offendersService.getRiskChangeForOffender.mockResolvedValue({
       violenceChange: true,
       bookingId: 12345,
-      newProfile: { violence: { numberOfSeriousAssaults: 1, numberOfAssaults: 2 } },
-      oldProfile: { violence: { numberOfSeriousAssaults: 1, numberOfAssaults: 1 } },
+      newProfile: { violence: { numberOfSeriousAssaults: 1, numberOfNonSeriousAssaults: 2, numberOfAssaults: 3 } },
+      oldProfile: { violence: { numberOfSeriousAssaults: 1, numberOfNonSeriousAssaults: 4, numberOfAssaults: 5 } },
     })
     return request(app)
       .get(`/riskProfileChangeDetail/12345`)
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).not.toContain('Extremism')
         expect(res.text).not.toContain('Risk of escape')
         expect(res.text).not.toContain('Security referral')
         expect(res.text).toContain(
-          'They have been reported as the perpetrator of 2 assaults in total during this sentence'
+          `They have been reported as the perpetrator of 3 assaults in custody before,
+      including 1 serious assaults and 2 non-serious assaults in the past 12 months`
         )
         expect(res.text).toContain(
-          'They have been reported as the perpetrator of 3 assaults in total during this sentence'
+          `They have been reported as the perpetrator of 5 assaults in custody before,
+      including 1 serious assaults and 4 non-serious assaults in the past 12 months`
         )
-        expect(res.text).toContain('Of these, 1 was a serious assault committed in the past 12 months')
       })
   })
 
   test('No violence change', () => {
     offendersService.getRiskChangeForOffender.mockResolvedValue({
       violenceChange: false,
-      notifyRegionalCTLeadExtremism: true,
       bookingId: 12345,
     })
     return request(app)
@@ -483,7 +460,6 @@ describe('GET /riskProfileChangeDetail/:bookingId', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Extremism')
         expect(res.text).not.toContain('Risk of escape')
         expect(res.text).not.toContain('Safety and good order')
         expect(res.text).not.toContain('Security referral')

--- a/test/routes/tasklist.test.js
+++ b/test/routes/tasklist.test.js
@@ -22,6 +22,7 @@ const formService = {
 
 const riskProfilerService = {
   getSecurityProfile: jest.fn(),
+  getExtremismProfile: jest.fn(),
 }
 
 const offendersService = {
@@ -106,7 +107,11 @@ describe('GET /tasklist/', () => {
       transferToSecurity: true,
       provisionalCategorisation: 'B',
     }
+    const sampleExtremismProfile = {
+      provisionalCategorisation: 'B',
+    }
     riskProfilerService.getSecurityProfile.mockResolvedValue(sampleSocProfile)
+    riskProfilerService.getExtremismProfile.mockResolvedValue(sampleExtremismProfile)
     formService.getCategorisationRecord.mockResolvedValue({
       id: 1111,
       securityReferredDate: `${todayISO}`,
@@ -127,6 +132,7 @@ describe('GET /tasklist/', () => {
           '12345',
           {
             socProfile: sampleSocProfile,
+            extremismProfile: sampleExtremismProfile,
           },
           mockTransactionalClient
         )
@@ -134,6 +140,7 @@ describe('GET /tasklist/', () => {
           '12345',
           'CA_USER_TEST',
           sampleSocProfile,
+          sampleExtremismProfile,
           'STARTED',
           mockTransactionalClient
         )

--- a/test/routes/tasklistRecat.test.js
+++ b/test/routes/tasklistRecat.test.js
@@ -23,6 +23,7 @@ const formService = {
 
 const riskProfilerService = {
   getSecurityProfile: jest.fn(),
+  getExtremismProfile: jest.fn(),
 }
 
 const offendersService = {
@@ -112,7 +113,11 @@ describe('GET /tasklistRecat/', () => {
       transferToSecurity: true,
       provisionalCategorisation: 'B',
     }
+    const sampleExtremismProfile = {
+      provisionalCategorisation: 'B',
+    }
     riskProfilerService.getSecurityProfile.mockResolvedValue(sampleSocProfile)
+    riskProfilerService.getExtremismProfile.mockResolvedValue(sampleExtremismProfile)
     formService.getCategorisationRecord.mockResolvedValue({
       id: 1111,
       securityReferredDate: `${todayISO}`,
@@ -131,13 +136,14 @@ describe('GET /tasklistRecat/', () => {
 
         expect(formService.mergeRiskProfileData).toBeCalledWith(
           '12345',
-          { socProfile: sampleSocProfile },
+          { socProfile: sampleSocProfile, extremismProfile: sampleExtremismProfile },
           mockTransactionalClient
         )
         expect(formService.referToSecurityIfRiskAssessed).toBeCalledWith(
           '12345',
           'CA_USER_TEST',
           sampleSocProfile,
+          sampleExtremismProfile,
           'STARTED',
           mockTransactionalClient
         )

--- a/test/services/sqsService.test.js
+++ b/test/services/sqsService.test.js
@@ -49,7 +49,7 @@ describe('rpQueueConsumer', () => {
       bookingId: 12,
       categoryCode: 'B',
     })
-    const newProfile = buildProfile({ increasedRiskOfExtremism: true })
+    const newProfile = buildProfile({ activeEscapeList: true })
     await service.rpQueueConsumer.handleMessage({
       Body: `{"offenderNo": "GN123", "oldProfile":${JSON.stringify(profile)}, "newProfile":${JSON.stringify(
         newProfile
@@ -68,8 +68,6 @@ function buildProfile({
   violentOffender = false,
   escapeListAlerts = [],
   escapeRiskAlerts = [],
-  notifyRCTL = false,
-  increasedRiskOfExtremism = false,
   socPC = 'C',
 } = {}) {
   return {
@@ -97,13 +95,6 @@ function buildProfile({
       numberOfSeriousAssaults: seriousAssaults,
       provisionalCategorisation: 'C',
       veryHighRiskViolentOffender: violentOffender,
-    },
-    extremism: {
-      nomsId: 'G1709GX',
-      riskType: 'EXTREMISM',
-      notifyRegionalCTLead: notifyRCTL,
-      increasedRiskOfExtremism,
-      provisionalCategorisation: 'C',
     },
   }
 }

--- a/test/utils/riskChange.test.js
+++ b/test/utils/riskChange.test.js
@@ -48,24 +48,6 @@ describe('it should assess the risk change status of a new and old risk profile 
     const newProfile = buildProfile({ provisionalCategorisation: 'B' })
     expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).violenceChange).toBe(true)
   })
-  it('Changes in extremism notify lead', () => {
-    const oldProfile = buildProfile({ notifyRegionalCTLead: false })
-    const newProfile = buildProfile({ notifyRegionalCTLead: true })
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).increasedRiskOfExtremism).toBe(false)
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).notifyRegionalCTLeadExtremism).toBe(true)
-  })
-  it('Changes in extremism increasedRiskOfExtremism', () => {
-    const oldProfile = buildProfile({ increasedRiskOfExtremism: false })
-    const newProfile = buildProfile({ increasedRiskOfExtremism: true })
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).increasedRiskOfExtremism).toBe(true)
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).notifyRegionalCTLeadExtremism).toBe(false)
-  })
-  it('Changes in extremism increasedRiskOfExtremism change to false is ignored', () => {
-    const oldProfile = buildProfile({ increasedRiskOfExtremism: true })
-    const newProfile = buildProfile({ increasedRiskOfExtremism: false })
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).increasedRiskOfExtremism).toBe(false)
-    expect(riskProfileHelper.assessRiskProfiles(oldProfile, newProfile).notifyRegionalCTLeadExtremism).toBe(false)
-  })
   it('Changes in soc referral notify lead', () => {
     const oldProfile = buildProfile({ transferToSecurity: false })
     const newProfile = buildProfile({ transferToSecurity: true })
@@ -81,14 +63,11 @@ function buildProfile({
   numberOfAssaults = 0,
   provisionalCategorisation = 'C',
   notifySafetyCustodyLead = false,
-  notifyRegionalCTLead = false,
-  increasedRiskOfExtremism = false,
   transferToSecurity = false,
 } = {}) {
   return {
     escape: { activeEscapeList, activeEscapeRisk, escapeRiskAlerts, escapeListAlerts },
     violence: { numberOfAssaults, provisionalCategorisation, notifySafetyCustodyLead },
-    extremism: { notifyRegionalCTLead, increasedRiskOfExtremism },
     soc: { transferToSecurity },
   }
 }


### PR DESCRIPTION
Automatically refer to security, like SOC cases and remove from list generated by batch
Also align text of assaults in custody from batch with online version.