### PR TITLE
CAT-1201 additional coverage for CAT-1180 epic

### DIFF
--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/ReviewPage.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/ReviewPage.groovy
@@ -36,5 +36,6 @@ class ReviewPage extends Page {
     previousSentences(required: false) { $('.previousSentencesSummary .govuk-summary-list__value') }
     sexualOffences(required: false) { $('.sexualOffencesSummary .govuk-summary-list__value') }
     victimContactScheme(required: false) { $('.victimContactSchemeSummary .govuk-summary-list__value') }
+    victimContactSchemeDl(required: false) { $('.victimContactSchemeSummary.no-print') }
   }
 }

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/recat/ReviewRecatPage.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/pages/recat/ReviewRecatPage.groovy
@@ -33,5 +33,6 @@ class ReviewRecatPage extends Page {
     foreignNational { $('.foreignNationalSummary .govuk-summary-list__value') }
     earliestReleaseDate(required: false) { $('.earliestReleaseDateSummary .govuk-summary-list__value') }
     victimContactScheme(required: false) { $('.victimContactSchemeSummary .govuk-summary-list__value') }
+    victimContactSchemeDl(required: false) { $('.victimContactSchemeSummary.no-print') }
   }
 }

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/OpenConditionsSpecification.groovy
@@ -397,6 +397,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
 
     earliestReleaseDate*.text() == ['', 'No', 'Not applicable']
     previousSentences*.text() == ['','No','Not applicable']
+    victimContactSchemeDl.displayed
     victimContactScheme*.text() == ['','No','Not applicable']
     sexualOffences*.text() == ['','No','Not applicable']
     foreignNational*.text() == ['', 'No', 'Not applicable', 'Not applicable', 'Not applicable']

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
@@ -67,6 +67,17 @@ class OpenConditionsSpecification extends AbstractSpecification {
     then: 'the Victim Contact Scheme page is displayed'
     at VictimContactSchemePage
 
+    when: 'I submit a blank page'
+    waitFor(5) {
+      submitButton.click()
+    }
+
+    then: 'there is a validation error'
+    waitFor {
+      errorSummaries*.text() == ['Select Yes if any victims of the crime have opted-in to the Victim Contact Scheme']
+      errors*.text() == ['Error:\nSelect Yes if any victims of the crime have opted-in to the Victim Contact Scheme']
+    }
+
     when: 'I submit page'
     vcsOptedForYes.click()
     contactedVLOYes.click()
@@ -218,6 +229,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     at ReviewRecatPage
 
     earliestReleaseDate*.text() == ['', 'No', 'Not applicable']
+    victimContactSchemeDl.displayed
     victimContactScheme*.text() == ['','No','Not applicable']
     foreignNational*.text() == ['', 'No', 'Not applicable', 'Not applicable', 'Not applicable']
     riskOfHarm*.text() == ['', 'No', 'Not applicable']

--- a/test/routes/openConditions.test.js
+++ b/test/routes/openConditions.test.js
@@ -179,18 +179,20 @@ describe('open conditions', () => {
   })
 
   test.each`
-    formName                 | userInput                                                                                     | updateInfo                                             | nextPath
-    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}        | ${'/form/openConditions/victimContactScheme/'}
-    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}      | ${'/form/openConditions/previousSentences/'}
-    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}             | ${'/form/openConditions/foreignNational/'}
-    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }} | ${'/form/openConditions/victimContactScheme/'}
-    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}           | ${'/form/openConditions/sexualOffences/'}
-    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                         | ${'/form/openConditions/riskOfHarm/'}
-    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                               | ${'/form/openConditions/furtherCharges/'}
-    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                  | ${'/form/openConditions/riskLevels/'}
-    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                              | ${'/tasklist/'}
-    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                | ${'/tasklistRecat/'}
-  `('Post $formName should go to $nextPath', ({ formName, userInput, updateInfo, nextPath }) => {
+    formName                 | userInput                                                                                     | updateInfo                                                         | nextPath
+    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}                    | ${'/form/openConditions/victimContactScheme/'}
+    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}                  | ${'/form/openConditions/previousSentences/'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                         | ${'/form/openConditions/foreignNational/'}
+    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }}             | ${'/form/openConditions/victimContactScheme/'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                       | ${'/form/openConditions/sexualOffences/'}
+    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                                     | ${'/form/openConditions/riskOfHarm/'}
+    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                                           | ${'/form/openConditions/furtherCharges/'}
+    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                              | ${'/form/openConditions/riskLevels/'}
+    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                                          | ${'/tasklist/'}
+    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                            | ${'/tasklistRecat/'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}                            | ${{ catType: 'INITIAL',  vcsOptedFor: 'Yes', contactedVLO: 'No' }} | ${'/form/openConditions/openConditionsNotSuitable/'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}                              | ${{ catType: 'RECAT',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}   | ${'/form/openConditions/openConditionsNotSuitable/'}
+  `('Post $formName for $userInput.catType should go to $nextPath', ({ formName, userInput, updateInfo, nextPath }) => {
     formService.getCategorisationRecord.mockResolvedValue({
       bookingId: 12,
       formObject: {},

--- a/test/routes/openConditions.test.js
+++ b/test/routes/openConditions.test.js
@@ -179,19 +179,19 @@ describe('open conditions', () => {
   })
 
   test.each`
-    formName                 | userInput                                                                                     | updateInfo                                                         | nextPath
-    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}                    | ${'/form/openConditions/victimContactScheme/'}
-    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}                  | ${'/form/openConditions/previousSentences/'}
-    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                         | ${'/form/openConditions/foreignNational/'}
-    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }}             | ${'/form/openConditions/victimContactScheme/'}
-    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                       | ${'/form/openConditions/sexualOffences/'}
-    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                                     | ${'/form/openConditions/riskOfHarm/'}
-    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                                           | ${'/form/openConditions/furtherCharges/'}
-    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                              | ${'/form/openConditions/riskLevels/'}
-    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                                          | ${'/tasklist/'}
-    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                            | ${'/tasklistRecat/'}
-    ${'victimContactScheme'} | ${{ catType: 'INITIAL',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}                            | ${{ catType: 'INITIAL',  vcsOptedFor: 'Yes', contactedVLO: 'No' }} | ${'/form/openConditions/openConditionsNotSuitable/'}
-    ${'victimContactScheme'} | ${{ catType: 'RECAT',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}                              | ${{ catType: 'RECAT',  vcsOptedFor: 'Yes', contactedVLO: 'No' }}   | ${'/form/openConditions/openConditionsNotSuitable/'}
+    formName                 | userInput                                                                                     | updateInfo                                                        | nextPath
+    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}                   | ${'/form/openConditions/victimContactScheme/'}
+    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}                 | ${'/form/openConditions/previousSentences/'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                        | ${'/form/openConditions/foreignNational/'}
+    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }}            | ${'/form/openConditions/victimContactScheme/'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                      | ${'/form/openConditions/sexualOffences/'}
+    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                                    | ${'/form/openConditions/riskOfHarm/'}
+    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                                          | ${'/form/openConditions/furtherCharges/'}
+    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                             | ${'/form/openConditions/riskLevels/'}
+    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                                         | ${'/tasklist/'}
+    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                           | ${'/tasklistRecat/'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                             | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }} | ${'/form/openConditions/openConditionsNotSuitable/'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                               | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}   | ${'/form/openConditions/openConditionsNotSuitable/'}
   `('Post $formName for $userInput.catType should go to $nextPath', ({ formName, userInput, updateInfo, nextPath }) => {
     formService.getCategorisationRecord.mockResolvedValue({
       bookingId: 12,


### PR DESCRIPTION
- added int test for  https://dsdmoj.atlassian.net/browse/CAT-797 AC 5 for RECAT
- added unit tests for https://dsdmoj.atlassian.net/browse/CAT-797 AC 9 for both INITIAL and RECAT
- https://dsdmoj.atlassian.net/browse/CAT-1220 int tests are only for initial and recat CYA pages, but that is sufficient as the code changes is done in a partial
- https://dsdmoj.atlassian.net/browse/CAT-1223 modified selectors in existing integration test to cover AC