### PR TITLE
CAT-1400 no print out of security information

### DIFF
--- a/server/views/formPages/recat/securityInput.html
+++ b/server/views/formPages/recat/securityInput.html
@@ -33,7 +33,9 @@
     label: {
       text: "Enter note"
     },
-    hint: { text: "Your comments will be disclosed to the prisoner" },
+    hint: {
+      text: "None of the information that you provide in the review will be disclosed to the prisoner. It will not be displayed when printing a completed review"
+    },
     value: data.recat.securityInput.securityInputNeededText,
     errorMessage: {
       text: "Enter a note"

--- a/server/views/formPages/security/review.html
+++ b/server/views/formPages/security/review.html
@@ -70,7 +70,7 @@
         text: "Enter details of any security information held on this prisoner, which could be relevant to their security categorisation"
       },
       hint: {
-        text: "Your comments may be disclosed to the prisoner"
+        text: "None of the information that you provide in the review will be disclosed to the prisoner. It will not be displayed when printing a completed review"
       },
       errorMessage: {
         text: (errors | findError('securityReview')).text

--- a/server/views/partials/reviewContents.html
+++ b/server/views/partials/reviewContents.html
@@ -167,7 +167,7 @@
   }) }}
 
   {% set wasReferred = data.socProfile.transferToSecurity or data.ratings.securityBack.catB or (user.activeCaseLoad.female and data.ratings.securityBack)%}
-  <h2 class="govuk-heading-m{{ ' no-print' if not wasReferred }}">Security information</h2>
+  <h2 class="govuk-heading-m no-print">Security information</h2>
   {% set auto = {
       classes: 'no-print',
       key: { text: "Automatic referral to security team" },
@@ -195,6 +195,7 @@
       actions: { items: [] }
     } %}
   {% set comments = {
+      classes: 'no-print',
       key: { text: "Security comments" },
       value: { text: data.security.review.securityReview },
       actions: { items: [] }
@@ -214,7 +215,7 @@
     } %}
 {% endif %}
   {{ govukSummaryList({
-    classes: 'govuk-!-margin-bottom-9 print-full-width securityInputSummary' + ('' if wasReferred else ' no-print'),
+    classes: 'govuk-!-margin-bottom-9 print-full-width securityInputSummary no-print',
     rows: [ auto, manual, flagged, comments, warrantS ] if wasReferred else [ auto, manual, flagged ]
   }) }}
 

--- a/server/views/partials/reviewContentsRecat.html
+++ b/server/views/partials/reviewContentsRecat.html
@@ -168,8 +168,8 @@
 
   {% set wasReferred = data.security.review.securityReview %}
   {% set title = {
-    key: { classes: 'summary-list-title' if wasReferred else 'summary-list-title no-print',
-      text: "Security information" },
+    key: { classes: 'summary-list-title no-print',
+    text: "Security information" },
     value: { classes: 'no-print'},
     actions: { classes: 'no-print',
         items: [{
@@ -199,13 +199,14 @@
       actions: { items: [] }
     } %}
   {% set comments = {
+      classes: 'no-print',
       key: { text: "Security comments" },
       value: { text: data.security.review.securityReview },
       actions: { items: [] }
     } %}
 
   {{ govukSummaryList({
-    classes: 'govuk-!-margin-bottom-9 print-full-width securityInputSummary' + ('' if wasReferred else ' no-print'),
+    classes: 'govuk-!-margin-bottom-9 print-full-width securityInputSummary no-print',
     rows: [ title, auto, manual, flagged, comments ] if wasReferred else [ title, auto, manual, flagged ]
   }) }}
 


### PR DESCRIPTION
CAT-1400 hide security information on print out of cat/recat/supervisor review pages for every user.