### PR TITLE
[CAT-1518] Adds direct SQL query testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   test:
     executor: builder
     environment:
-      POSTGRES_HOSTNAME: form-db-unit-tests
+#      POSTGRES_HOSTNAME: form-db-unit-tests
       DB_PORT: 5432
       POSTGRES_PORT: 5432
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,17 @@ jobs:
           - assets/stylesheets
   test:
     executor: builder
+    environment:
+      POSTGRES_HOSTNAME: form-db-unit-tests
+      POSTGRES_PORT: 5432
+    docker:
+      - image: cimg/node:<< pipeline.parameters.node-version >>
+      - image: cimg/postgres:14.3
+        name: form-db-unit-tests
+        environment:
+          POSTGRES_USER: form-builder-unit-tests
+          POSTGRES_PASSWORD: form-builder-unit-tests
+          POSTGRES_DB: form-builder-unit-tests
     steps:
     - checkout
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
     environment:
       POSTGRES_HOSTNAME: form-db-unit-tests
       DB_PORT: 5432
+      POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
       - image: cimg/postgres:14.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,13 @@ jobs:
       POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
+        environment:
+          POSTGRES_USER: form-builder-unit-tests
+          POSTGRES_PASSWORD: form-builder-unit-tests
+          POSTGRES_DB: form-builder-unit-tests
+          DB_PORT: 5432
+          POSTGRES_HOSTNAME: form-db-unit-tests
+          POSTGRES_PORT: 5432
       - image: cimg/postgres:14.3
         name: form-db-unit-tests
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
     executor: builder
     environment:
       POSTGRES_HOSTNAME: form-db-unit-tests
-      POSTGRES_PORT: 5432
+      DB_PORT: 5432
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
       - image: cimg/postgres:14.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   test:
     executor: builder
     environment:
-#      POSTGRES_HOSTNAME: form-db-unit-tests
+      POSTGRES_HOSTNAME: form-db-unit-tests
       DB_PORT: 5432
       POSTGRES_PORT: 5432
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
     environment:
       DB_SERVER: form-db-unit-tests
       DB_PORT: 5432
+      POSTGRES_PORT: 5432
+      POSTGRES_HOSTNAME: form-db-unit-tests
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
       - image: cimg/postgres:14.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,18 +52,10 @@ jobs:
   test:
     executor: builder
     environment:
+      DB_SERVER: form-db-unit-tests
       DB_PORT: 5432
-      POSTGRES_HOSTNAME: form-db-unit-tests
-      POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
-        environment:
-          POSTGRES_USER: form-builder-unit-tests
-          POSTGRES_PASSWORD: form-builder-unit-tests
-          POSTGRES_DB: form-builder-unit-tests
-          DB_PORT: 5432
-          POSTGRES_HOSTNAME: form-db-unit-tests
-          POSTGRES_PORT: 5432
       - image: cimg/postgres:14.3
         name: form-db-unit-tests
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ jobs:
   test:
     executor: builder
     environment:
-      POSTGRES_HOSTNAME: form-db-unit-tests
       DB_PORT: 5432
+      POSTGRES_HOSTNAME: form-db-unit-tests
       POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>

--- a/.env.unit-tests
+++ b/.env.unit-tests
@@ -3,4 +3,3 @@ DB_PASS=form-builder-unit-tests
 DB_SERVER=0.0.0.0
 DB_NAME=form-builder-unit-tests
 DB_PORT=5434
-ANYTHING=goeshere

--- a/.env.unit-tests
+++ b/.env.unit-tests
@@ -1,0 +1,6 @@
+DB_USER=form-builder-unit-tests
+DB_PASS=form-builder-unit-tests
+DB_SERVER=0.0.0.0
+DB_NAME=form-builder-unit-tests
+DB_PORT=5434
+ANYTHING=goeshere

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -12,6 +12,21 @@ services:
       - POSTGRES_PASSWORD=form-builder
       - POSTGRES_USER=form-builder
       - POSTGRES_DB=form-builder
+    command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
+
+  form-db-unit-tests:
+    image: postgres
+    networks:
+      - hmpps
+    container_name: form-builder-db-unit-tests
+    restart: always
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_PASSWORD=form-builder-unit-tests
+      - POSTGRES_USER=form-builder-unit-tests
+      - POSTGRES_DB=form-builder-unit-tests
+    command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
 
   categorisation-redis:
     image: redis

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+const config = {
+  setupFiles: ['<rootDir>/test/setup/jest-setup.js'],
+}
+
+module.exports = config

--- a/server/config.js
+++ b/server/config.js
@@ -40,6 +40,7 @@ module.exports = {
     password: get('DB_PASS', 'form-builder'),
     server: get('DB_SERVER', 'localhost', true),
     database: get('DB_NAME', 'form-builder', true),
+    port: get('DB_PORT', 5432, true),
     sslEnabled: get('DB_SSL_ENABLED', 'false', true),
   },
   sqs: {

--- a/server/data/dataAccess/db.js
+++ b/server/data/dataAccess/db.js
@@ -10,7 +10,7 @@ const pool = new Pool({
   host: config.db.server,
   database: config.db.database,
   password: config.db.password,
-  port: 5432,
+  port: config.db.port,
   ssl:
     config.db.sslEnabled === 'true'
       ? {

--- a/test/data/queries/getTprsTotals.test.js
+++ b/test/data/queries/getTprsTotals.test.js
@@ -1,0 +1,220 @@
+const ramda = require('ramda')
+const { database } = require('../../setup')
+const client = require('../../../server/data/statsClient')
+const CatType = require('../../../server/utils/catTypeEnum')
+const StatsType = require('../../../server/utils/statsTypeEnum')
+const { fakePrisoner } = require('../../fake-data/prisoners')
+const { doTransactional } = require('../../../server/data/dataAccess/db')
+const prisons = require('../../fake-data/prisons')
+
+const tprsSelectedYes = { form_response: { openConditions: { tprsSelected: 'Yes' } } }
+const tprsSelectedNo = { form_response: { openConditions: { tprsSelected: 'No' } } }
+const supervisorOverriddenCategory = supervisorOverriddenCat => ({
+  form_response: {
+    supervisor: { review: { supervisorOverriddenCategory: supervisorOverriddenCat } },
+  },
+})
+const recatDecision = recategorisationDecision => ({
+  form_response: { recat: { decision: { category: recategorisationDecision } } },
+})
+const initialCategoryOverridden = initialCategoryOverride => ({
+  form_response: {
+    categoriser: { provisionalCategory: { overriddenCategory: initialCategoryOverride } },
+  },
+})
+const initialCategorySuggested = initialCategorySuggestion => ({
+  form_response: {
+    categoriser: { provisionalCategory: { suggestedCategory: initialCategorySuggestion } },
+  },
+})
+const initialCategory = initialCat => ({ form_response: { ratings: { decision: { category: initialCat } } } })
+
+describe('getTprsTotals', () => {
+  let startDate
+  let endDate
+
+  beforeEach(async () => {
+    await database.setUp()
+  })
+
+  afterEach(async () => {
+    await database.tearDown()
+  })
+
+  beforeEach(() => {
+    startDate = '2022-01-01'
+    endDate = '2022-01-28'
+  })
+
+  test('no results in the database', async () => {
+    await doTransactional(async dbClient => {
+      const result = await client.getTprsTotals(CatType.INITIAL.name, startDate, endDate, 'ANY', dbClient)
+      expect(result.rows).toEqual([{ tprs_selected: 0 }])
+    })
+  })
+
+  describe(`with a defined prisonId`, () => {
+    describe(`men's estate`, () => {
+      test('initial categorisation returns expected query and values', async () => {
+        await database.knex('form').insert(fakePrisoner(1))
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.INITIAL.name,
+            startDate,
+            endDate,
+            prisons.ADULT.MENS.PETERBOROUGH,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 1 }])
+        })
+      })
+
+      test(`recategorisation returns expected query and values`, async () => {
+        const prisoner1 = fakePrisoner(1)
+        const prisoner2 = fakePrisoner(2, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...supervisorOverriddenCategory('D'),
+        })
+        const prisoner3 = fakePrisoner(3, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...recatDecision('J'),
+        })
+        const prisoner4 = fakePrisoner(4, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...recatDecision('T'),
+        })
+        const prisoner5 = fakePrisoner(5, {
+          ...recatDecision('T'),
+        })
+
+        await database.knex('form').insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5])
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.INITIAL.name,
+            startDate,
+            endDate,
+            prisons.ADULT.MENS.LIVERPOOL,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 3 }])
+        })
+      })
+    })
+
+    describe(`women's estate`, () => {
+      test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
+        const startDateOverride = '2021-11-01'
+        const endDateOverride = '2021-11-01'
+
+        await database.knex('form').insert(
+          fakePrisoner(1, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDateOverride,
+          })
+        )
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.INITIAL.name,
+            startDateOverride,
+            endDateOverride,
+            prisons.ADULT.WOMENS.PETERBOROUGH,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 1 }])
+        })
+      })
+
+      test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
+        const prisoner1 = fakePrisoner(1)
+        const prisoner2 = fakePrisoner(2, {
+          prison_id: prisons.ADULT.WOMENS.LIVERPOOL,
+          ...supervisorOverriddenCategory('D'),
+        })
+        const prisoner3 = fakePrisoner(3, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...recatDecision('J'),
+        })
+        const prisoner4 = fakePrisoner(4, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...recatDecision('T'),
+        })
+        const prisoner5 = fakePrisoner(5, {
+          ...recatDecision('T'),
+        })
+
+        await database.knex('form').insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5])
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.INITIAL.name,
+            startDate,
+            endDate,
+            prisons.ADULT.MENS.LIVERPOOL,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 3 }])
+        })
+      })
+    })
+  })
+
+  // describe(`without a defined prisonId`, () => {
+  //   describe(`men's estate`, () => {
+  //     let notInWomensPrisonIdsClause
+  //
+  //     beforeEach(() => {
+  //       notInWomensPrisonIdsClause = ` and prison_id not in ('AGI','DWI','DHI','ESI','EWI','BZI','FHI','LNI','SDI','STI','NHI','PFI'))`
+  //     })
+  //
+  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly StatsType.MALE', async () => {
+  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, StatsType.MALE)
+  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
+  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
+  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
+  //     })
+  //
+  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly null', async () => {
+  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, null)
+  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
+  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
+  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
+  //     })
+  //
+  //     test(`getRecategorisationTprsTotalsQuery returns expected query and values when prisonId is not provided`, async () => {
+  //       const actualResult = client.getTprsTotalsQuery(CatType.RECAT.name, startDate, endDate)
+  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
+  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
+  //       expect(actualResult.values).toEqual([CatType.RECAT.name, startDate, endDate])
+  //     })
+  //   })
+  //
+  //   describe(`women's estate`, () => {
+  //     let inWomensPrisonClause
+  //
+  //     beforeEach(() => {
+  //       inWomensPrisonClause = `and prison_id in ('AGI','DWI','DHI','ESI','EWI','BZI','FHI','LNI','SDI','STI','NHI','PFI'))`
+  //     })
+  //
+  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
+  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, StatsType.FEMALE)
+  //       const expectedSql = sanitiseString(`${commonTableExpression} ${inWomensPrisonClause} ${commonQuery}`)
+  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
+  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
+  //     })
+  //
+  //     test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
+  //       const actualResult = client.getTprsTotalsQuery(CatType.RECAT.name, startDate, endDate, StatsType.FEMALE)
+  //       const expectedSql = sanitiseString(`${commonTableExpression} ${inWomensPrisonClause} ${commonQuery}`)
+  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
+  //       expect(actualResult.values).toEqual([CatType.RECAT.name, startDate, endDate])
+  //     })
+  //   })
+  // })
+})

--- a/test/data/queries/getTprsTotals.test.js
+++ b/test/data/queries/getTprsTotals.test.js
@@ -153,34 +153,33 @@ describe('getTprsTotals', () => {
             approval_date: startDate,
             ...initialCategory('C'),
           }),
-          // // included, correct category
-          // fakePrisoner(3, {
-          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
-          //   approval_date: startDate,
-          //   ...{ form_response: { supervisor: {} } },
-          //   ...initialCategory('D'),
-          // }),
-          // // included, override initial category regrades to open
-          // fakePrisoner(4, {
-          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
-          //   approval_date: startDate,
-          //   ...{ form_response: { supervisor: {} } },
-          //   ...initialCategory('C'),
-          //   ...initialCategoryOverridden('J'),
-          // }),
-
-          // fakePrisoner(4, {
-          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
-          //   approval_date: startDate,
-          //   ...initialCategoryOverridden('J'),
-          // }),
+          // included, correct category
+          fakePrisoner(3, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDate,
+            ...initialCategory('D'),
+          }),
+          // included, override initial category regrades to open
+          fakePrisoner(4, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDate,
+            ...initialCategory('C'),
+            ...initialCategoryOverridden('J'),
+          }),
+          // excluded, supervisor overrules
+          fakePrisoner(5, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDate,
+            ...initialCategoryOverridden('D'),
+            ...supervisorOverriddenCategory('C'),
+          }),
           // excluded as wrong category
-          // fakePrisoner(5, {
-          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
-          //   approval_date: startDate,
-          //   ...initialCategory('C'),
-          //   ...initialCategoryOverridden('B'),
-          // }),
+          fakePrisoner(6, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDate,
+            ...initialCategory('C'),
+            ...initialCategoryOverridden('B'),
+          }),
         ])
 
         await doTransactional(async dbClient => {
@@ -192,7 +191,7 @@ describe('getTprsTotals', () => {
             dbClient
           )
 
-          expect(result.rows).toEqual([{ tprs_selected: 0 }])
+          expect(result.rows).toEqual([{ tprs_selected: 2 }])
         })
       })
 

--- a/test/data/queries/getTprsTotals.test.js
+++ b/test/data/queries/getTprsTotals.test.js
@@ -1,4 +1,3 @@
-const ramda = require('ramda')
 const { database } = require('../../setup')
 const client = require('../../../server/data/statsClient')
 const CatType = require('../../../server/utils/catTypeEnum')
@@ -6,9 +5,10 @@ const StatsType = require('../../../server/utils/statsTypeEnum')
 const { fakePrisoner } = require('../../fake-data/prisoners')
 const { doTransactional } = require('../../../server/data/dataAccess/db')
 const prisons = require('../../fake-data/prisons')
+const Status = require('../../../server/utils/statusEnum')
 
-const tprsSelectedYes = { form_response: { openConditions: { tprsSelected: 'Yes' } } }
-const tprsSelectedNo = { form_response: { openConditions: { tprsSelected: 'No' } } }
+const tprsSelectedYes = { form_response: { openConditions: { tprs: { tprsSelected: 'Yes' } } } }
+const tprsSelectedNo = { form_response: { openConditions: { tprs: { tprsSelected: 'No' } } } }
 const supervisorOverriddenCategory = supervisorOverriddenCat => ({
   form_response: {
     supervisor: { review: { supervisorOverriddenCategory: supervisorOverriddenCat } },
@@ -56,7 +56,11 @@ describe('getTprsTotals', () => {
   describe(`with a defined prisonId`, () => {
     describe(`men's estate`, () => {
       test('initial categorisation returns expected query and values', async () => {
-        await database.knex('form').insert(fakePrisoner(1))
+        await database.knex('form').insert(
+          fakePrisoner(1, {
+            ...initialCategory('J'),
+          })
+        )
 
         await doTransactional(async dbClient => {
           const result = await client.getTprsTotals(
@@ -72,28 +76,53 @@ describe('getTprsTotals', () => {
       })
 
       test(`recategorisation returns expected query and values`, async () => {
-        const prisoner1 = fakePrisoner(1)
+        // no recat decision
+        const prisoner1 = fakePrisoner(1, {
+          cat_type: CatType.RECAT.name,
+        })
         const prisoner2 = fakePrisoner(2, {
           prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          cat_type: CatType.RECAT.name,
+          // explicitly checking tprsSelected value
+          ...tprsSelectedYes,
           ...supervisorOverriddenCategory('D'),
         })
         const prisoner3 = fakePrisoner(3, {
           prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          cat_type: CatType.RECAT.name,
           ...recatDecision('J'),
         })
         const prisoner4 = fakePrisoner(4, {
           prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          cat_type: CatType.RECAT.name,
           ...recatDecision('T'),
         })
+        // not at the interesting prison
         const prisoner5 = fakePrisoner(5, {
+          cat_type: CatType.RECAT.name,
           ...recatDecision('T'),
+        })
+        // wrong cat type
+        const prisoner6 = fakePrisoner(6, {
+          cat_type: CatType.INITIAL.name,
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          ...recatDecision('T'),
+        })
+        // explicitly tprsSelected: 'no'
+        const prisoner7 = fakePrisoner(7, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          cat_type: CatType.RECAT.name,
+          ...recatDecision('T'),
+          ...tprsSelectedNo,
         })
 
-        await database.knex('form').insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5])
+        await database
+          .knex('form')
+          .insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5, prisoner6, prisoner7])
 
         await doTransactional(async dbClient => {
           const result = await client.getTprsTotals(
-            CatType.INITIAL.name,
+            CatType.RECAT.name,
             startDate,
             endDate,
             prisons.ADULT.MENS.LIVERPOOL,
@@ -106,115 +135,236 @@ describe('getTprsTotals', () => {
     })
 
     describe(`women's estate`, () => {
-      test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
-        const startDateOverride = '2021-11-01'
-        const endDateOverride = '2021-11-01'
-
-        await database.knex('form').insert(
-          fakePrisoner(1, {
-            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
-            approval_date: startDateOverride,
-          })
-        )
-
-        await doTransactional(async dbClient => {
-          const result = await client.getTprsTotals(
-            CatType.INITIAL.name,
-            startDateOverride,
-            endDateOverride,
-            prisons.ADULT.WOMENS.PETERBOROUGH,
-            dbClient
-          )
-
-          expect(result.rows).toEqual([{ tprs_selected: 1 }])
-        })
+      beforeEach(() => {
+        startDate = '2021-11-01'
+        endDate = '2021-11-01'
       })
 
-      test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
-        const prisoner1 = fakePrisoner(1)
-        const prisoner2 = fakePrisoner(2, {
-          prison_id: prisons.ADULT.WOMENS.LIVERPOOL,
-          ...supervisorOverriddenCategory('D'),
-        })
-        const prisoner3 = fakePrisoner(3, {
-          prison_id: prisons.ADULT.MENS.LIVERPOOL,
-          ...recatDecision('J'),
-        })
-        const prisoner4 = fakePrisoner(4, {
-          prison_id: prisons.ADULT.MENS.LIVERPOOL,
-          ...recatDecision('T'),
-        })
-        const prisoner5 = fakePrisoner(5, {
-          ...recatDecision('T'),
-        })
+      test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
+        await database.knex('form').insert([
+          // excluded, wrong prison id
+          fakePrisoner(1, {
+            prison_id: prisons.ADULT.WOMENS.FOSTON_HALL,
+            approval_date: startDate,
+          }),
+          // excluded, wrong initial category
+          fakePrisoner(2, {
+            prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+            approval_date: startDate,
+            ...initialCategory('C'),
+          }),
+          // // included, correct category
+          // fakePrisoner(3, {
+          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          //   approval_date: startDate,
+          //   ...{ form_response: { supervisor: {} } },
+          //   ...initialCategory('D'),
+          // }),
+          // // included, override initial category regrades to open
+          // fakePrisoner(4, {
+          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          //   approval_date: startDate,
+          //   ...{ form_response: { supervisor: {} } },
+          //   ...initialCategory('C'),
+          //   ...initialCategoryOverridden('J'),
+          // }),
 
-        await database.knex('form').insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5])
+          // fakePrisoner(4, {
+          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          //   approval_date: startDate,
+          //   ...initialCategoryOverridden('J'),
+          // }),
+          // excluded as wrong category
+          // fakePrisoner(5, {
+          //   prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          //   approval_date: startDate,
+          //   ...initialCategory('C'),
+          //   ...initialCategoryOverridden('B'),
+          // }),
+        ])
 
         await doTransactional(async dbClient => {
           const result = await client.getTprsTotals(
             CatType.INITIAL.name,
             startDate,
             endDate,
-            prisons.ADULT.MENS.LIVERPOOL,
+            prisons.ADULT.WOMENS.PETERBOROUGH,
             dbClient
           )
 
-          expect(result.rows).toEqual([{ tprs_selected: 3 }])
+          expect(result.rows).toEqual([{ tprs_selected: 0 }])
+        })
+      })
+
+      test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
+        const prisoner1 = fakePrisoner(1)
+        const prisoner2 = fakePrisoner(2, {
+          prison_id: prisons.ADULT.WOMENS.FOSTON_HALL,
+          cat_type: CatType.RECAT.name,
+          ...supervisorOverriddenCategory('D'),
+          approval_date: startDate,
+        })
+        // not at the interesting prison
+        const prisoner3 = fakePrisoner(3, {
+          prison_id: prisons.ADULT.MENS.LIVERPOOL,
+          cat_type: CatType.RECAT.name,
+          ...recatDecision('J'),
+        })
+        const prisoner4 = fakePrisoner(4, {
+          prison_id: prisons.ADULT.WOMENS.FOSTON_HALL,
+          cat_type: CatType.RECAT.name,
+          ...recatDecision('T'),
+          approval_date: startDate,
+        })
+        // not inside the queried approval date range
+        const prisoner5 = fakePrisoner(5, {
+          ...recatDecision('T'),
+          cat_type: CatType.RECAT.name,
+          prison_id: prisons.ADULT.WOMENS.FOSTON_HALL,
+          approval_date: '2021-11-03',
+        })
+        // wrong approval status
+        const prisoner6 = fakePrisoner(6, {
+          prison_id: prisons.ADULT.WOMENS.FOSTON_HALL,
+          cat_type: CatType.RECAT.name,
+          ...recatDecision('T'),
+          approval_date: startDate,
+          status: Status.SECURITY_BACK.name,
+        })
+
+        await database.knex('form').insert([prisoner1, prisoner2, prisoner3, prisoner4, prisoner5, prisoner6])
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.RECAT.name,
+            startDate,
+            endDate,
+            prisons.ADULT.WOMENS.FOSTON_HALL,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 2 }])
         })
       })
     })
   })
 
-  // describe(`without a defined prisonId`, () => {
-  //   describe(`men's estate`, () => {
-  //     let notInWomensPrisonIdsClause
-  //
-  //     beforeEach(() => {
-  //       notInWomensPrisonIdsClause = ` and prison_id not in ('AGI','DWI','DHI','ESI','EWI','BZI','FHI','LNI','SDI','STI','NHI','PFI'))`
-  //     })
-  //
-  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly StatsType.MALE', async () => {
-  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, StatsType.MALE)
-  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
-  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
-  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
-  //     })
-  //
-  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly null', async () => {
-  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, null)
-  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
-  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
-  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
-  //     })
-  //
-  //     test(`getRecategorisationTprsTotalsQuery returns expected query and values when prisonId is not provided`, async () => {
-  //       const actualResult = client.getTprsTotalsQuery(CatType.RECAT.name, startDate, endDate)
-  //       const expectedSql = sanitiseString(`${commonTableExpression} ${notInWomensPrisonIdsClause} ${commonQuery}`)
-  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
-  //       expect(actualResult.values).toEqual([CatType.RECAT.name, startDate, endDate])
-  //     })
-  //   })
-  //
-  //   describe(`women's estate`, () => {
-  //     let inWomensPrisonClause
-  //
-  //     beforeEach(() => {
-  //       inWomensPrisonClause = `and prison_id in ('AGI','DWI','DHI','ESI','EWI','BZI','FHI','LNI','SDI','STI','NHI','PFI'))`
-  //     })
-  //
-  //     test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
-  //       const actualResult = client.getTprsTotalsQuery(CatType.INITIAL.name, startDate, endDate, StatsType.FEMALE)
-  //       const expectedSql = sanitiseString(`${commonTableExpression} ${inWomensPrisonClause} ${commonQuery}`)
-  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
-  //       expect(actualResult.values).toEqual([CatType.INITIAL.name, startDate, endDate])
-  //     })
-  //
-  //     test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
-  //       const actualResult = client.getTprsTotalsQuery(CatType.RECAT.name, startDate, endDate, StatsType.FEMALE)
-  //       const expectedSql = sanitiseString(`${commonTableExpression} ${inWomensPrisonClause} ${commonQuery}`)
-  //       expect(expectedSql).toEqual(sanitiseString(actualResult.text))
-  //       expect(actualResult.values).toEqual([CatType.RECAT.name, startDate, endDate])
-  //     })
-  //   })
-  // })
+  describe(`without a defined prisonId`, () => {
+    describe(`men's estate`, () => {
+      test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly StatsType.MALE', async () => {
+        const fakePrisoners = [...Array(99)].map((_, i) =>
+          fakePrisoner(i, {
+            prison_id: i % 2 === 0 ? prisons.ADULT.MENS.LIVERPOOL : prisons.ADULT.MENS.PETERBOROUGH,
+            ...initialCategorySuggested(i % 2 === 0 ? 'J' : 'C'),
+          })
+        )
+
+        await database.knex('form').insert(fakePrisoners)
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(CatType.INITIAL.name, startDate, endDate, StatsType.MALE, dbClient)
+
+          expect(result.rows).toEqual([{ tprs_selected: 50 }])
+        })
+      })
+
+      test('getInitialCategorisationTprsTotalsQuery returns expected query and values when prisonId is explicitly null', async () => {
+        const fakePrisoners = [...Array(44)].map((_, i) =>
+          fakePrisoner(i, {
+            prison_id: i % 2 !== 0 ? prisons.ADULT.MENS.PETERBOROUGH : prisons.ADULT.MENS.LIVERPOOL,
+            ...initialCategoryOverridden(i % 2 === 0 ? 'T' : 'J'),
+          })
+        )
+
+        await database.knex('form').insert(fakePrisoners)
+
+        const prisonId = null
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(CatType.INITIAL.name, startDate, endDate, prisonId, dbClient)
+
+          expect(result.rows).toEqual([{ tprs_selected: 44 }])
+        })
+      })
+
+      test(`getRecategorisationTprsTotalsQuery returns expected query and values when prisonId is not provided`, async () => {
+        const fakePrisoners = [...Array(123)].map((_, i) =>
+          fakePrisoner(i, {
+            prison_id: i % 2 === 0 ? prisons.ADULT.MENS.LIVERPOOL : prisons.ADULT.MENS.PETERBOROUGH,
+            cat_type: CatType.RECAT.name,
+            ...recatDecision(i % 2 === 0 ? 'T' : 'D'),
+          })
+        )
+
+        await database.knex('form').insert(fakePrisoners)
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(CatType.RECAT.name, startDate, endDate, StatsType.MALE, dbClient)
+
+          expect(result.rows).toEqual([{ tprs_selected: 123 }])
+        })
+      })
+    })
+
+    describe(`women's estate`, () => {
+      test('getInitialCategorisationTprsTotalsQuery returns expected query and values', async () => {
+        const fakePrisoners = [...Array(11)].map((_, i) =>
+          fakePrisoner(i, {
+            // either a woman's or a man's prison here
+            prison_id: i % 2 === 0 ? prisons.ADULT.WOMENS.FOSTON_HALL : prisons.ADULT.MENS.PETERBOROUGH,
+            ...initialCategory('D'),
+          })
+        )
+        const additionalFakeFemalePrisoner = fakePrisoner(111, {
+          prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          ...supervisorOverriddenCategory('D'),
+        })
+
+        await database.knex('form').insert([...fakePrisoners, additionalFakeFemalePrisoner])
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(
+            CatType.INITIAL.name,
+            startDate,
+            endDate,
+            StatsType.FEMALE,
+            dbClient
+          )
+
+          expect(result.rows).toEqual([{ tprs_selected: 7 }])
+        })
+      })
+
+      test(`getRecategorisationTprsTotalsQuery returns expected query and values`, async () => {
+        const fakePrisoners = [...Array(11)].map((_, i) =>
+          fakePrisoner(i, {
+            prison_id: i % 2 === 0 ? prisons.ADULT.WOMENS.FOSTON_HALL : prisons.ADULT.WOMENS.PETERBOROUGH,
+            cat_type: CatType.RECAT.name,
+            ...recatDecision(i % 2 === 0 ? 'C' : 'D'),
+          })
+        )
+        // not a recat
+        const additionalFakeFemalePrisoner1 = fakePrisoner(111, {
+          prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+        })
+        // supervisor override to open
+        const additionalFakeFemalePrisoner2 = fakePrisoner(222, {
+          prison_id: prisons.ADULT.WOMENS.PETERBOROUGH,
+          cat_type: CatType.RECAT.name,
+          ...recatDecision('B'),
+          ...supervisorOverriddenCategory('J'),
+        })
+
+        await database
+          .knex('form')
+          .insert([...fakePrisoners, additionalFakeFemalePrisoner1, additionalFakeFemalePrisoner2])
+
+        await doTransactional(async dbClient => {
+          const result = await client.getTprsTotals(CatType.RECAT.name, startDate, endDate, StatsType.FEMALE, dbClient)
+
+          expect(result.rows).toEqual([{ tprs_selected: 6 }])
+        })
+      })
+    })
+  })
 })

--- a/test/fake-data/prisoners.js
+++ b/test/fake-data/prisoners.js
@@ -1,5 +1,7 @@
 const ramda = require('ramda')
 const prisons = require('./prisons')
+const CatType = require('../../server/utils/catTypeEnum')
+const Status = require('../../server/utils/statusEnum')
 
 const fakePrisoner = (id, fields = {}) =>
   ramda.mergeDeepRight(
@@ -15,27 +17,8 @@ const fakePrisoner = (id, fields = {}) =>
           extremismRating: { previousTerrorismOffences: 'No' },
           offendingHistory: { previousConvictions: 'Yes', previousConvictionsText: 'some convictions' },
         },
-        supervisor: {
-          review: {
-            proposedCategory: 'D',
-            otherInformationText: 'super other info 1',
-            previousOverrideCategoryText: 'super overriding C to D reason text',
-            supervisorCategoryAppropriate: 'Yes',
-          },
-          confirmBack: {
-            isRead: true,
-            messageText: 'super overriding C to D reason text',
-            supervisorName: 'Test User',
-          },
-        },
-        categoriser: {
-          review: {},
-          provisionalCategory: {
-            suggestedCategory: 'D',
-            categoryAppropriate: 'Yes',
-            otherInformationText: 'categoriser relevant info for accept',
-          },
-        },
+        supervisor: {},
+        categoriser: {},
         openConditions: {
           tprs: { tprsSelected: 'Yes' },
           riskLevels: { likelyToAbscond: 'No' },
@@ -55,7 +38,7 @@ const fakePrisoner = (id, fields = {}) =>
       },
       booking_id: id,
       user_id: 'user123',
-      status: 'APPROVED',
+      status: Status.APPROVED.name,
       assigned_user_id: 'user456',
       referred_date: '2022-02-01T10:30:00Z',
       referred_by: 'referral123',
@@ -71,7 +54,7 @@ const fakePrisoner = (id, fields = {}) =>
       security_reviewed_by: 'security123',
       security_reviewed_date: '2022-01-15T10:30:00Z',
       approval_date: '2022-01-24',
-      cat_type: 'INITIAL',
+      cat_type: CatType.INITIAL.name,
       nomis_sequence_no: id,
       assessment_date: '2022-01-10',
       approved_by: 'approver123',

--- a/test/fake-data/prisoners.js
+++ b/test/fake-data/prisoners.js
@@ -1,0 +1,89 @@
+const ramda = require('ramda')
+const prisons = require('./prisons')
+
+const fakePrisoner = (id, fields = {}) =>
+  ramda.mergeDeepRight(
+    {
+      id,
+      form_response: {
+        ratings: {
+          escapeRating: { escapeOtherEvidence: 'No' },
+          securityInput: { securityInputNeeded: 'No' },
+          furtherCharges: { furtherCharges: 'No' },
+          nextReviewDate: { date: '14/12/2019' },
+          violenceRating: { seriousThreat: 'No', highRiskOfViolence: 'No' },
+          extremismRating: { previousTerrorismOffences: 'No' },
+          offendingHistory: { previousConvictions: 'Yes', previousConvictionsText: 'some convictions' },
+        },
+        supervisor: {
+          review: {
+            proposedCategory: 'D',
+            otherInformationText: 'super other info 1',
+            previousOverrideCategoryText: 'super overriding C to D reason text',
+            supervisorCategoryAppropriate: 'Yes',
+          },
+          confirmBack: {
+            isRead: true,
+            messageText: 'super overriding C to D reason text',
+            supervisorName: 'Test User',
+          },
+        },
+        categoriser: {
+          review: {},
+          provisionalCategory: {
+            suggestedCategory: 'D',
+            categoryAppropriate: 'Yes',
+            otherInformationText: 'categoriser relevant info for accept',
+          },
+        },
+        openConditions: {
+          tprs: { tprsSelected: 'Yes' },
+          riskLevels: { likelyToAbscond: 'No' },
+          riskOfHarm: { seriousHarm: 'No' },
+          furtherCharges: {
+            increasedRisk: 'No',
+            furtherCharges: 'Yes',
+            furtherChargesText: ',furtherChargesText details',
+          },
+          sexualOffences: { haveTheyBeenEverConvicted: 'No' },
+          foreignNational: { isForeignNational: 'No' },
+          previousSentences: { releasedLastFiveYears: 'No' },
+          earliestReleaseDate: { threeOrMoreYears: 'No' },
+          victimContactScheme: { vcsOptedFor: 'No' },
+        },
+        openConditionsRequested: true,
+      },
+      booking_id: id,
+      user_id: 'user123',
+      status: 'APPROVED',
+      assigned_user_id: 'user456',
+      referred_date: '2022-02-01T10:30:00Z',
+      referred_by: 'referral123',
+      sequence_no: id,
+      risk_profile: {
+        risk_factor1: true,
+        risk_factor2: false,
+        risk_factor3: true,
+      },
+      prison_id: prisons.ADULT.MENS.PETERBOROUGH,
+      offender_no: `FAKE${id}`,
+      start_date: '2022-01-01T12:00:00Z',
+      security_reviewed_by: 'security123',
+      security_reviewed_date: '2022-01-15T10:30:00Z',
+      approval_date: '2022-01-24',
+      cat_type: 'INITIAL',
+      nomis_sequence_no: id,
+      assessment_date: '2022-01-10',
+      approved_by: 'approver123',
+      assessed_by: 'assessor123',
+      review_reason: 'MANUAL',
+      due_by_date: '2022-02-28',
+      cancelled_date: null,
+      cancelled_by: null,
+    },
+    fields
+  )
+
+module.exports = {
+  fakePrisoner,
+}

--- a/test/fake-data/prisons.js
+++ b/test/fake-data/prisons.js
@@ -5,6 +5,7 @@ const PRISONS = {
       PETERBOROUGH: 'PBI',
     },
     WOMENS: {
+      FOSTON_HALL: 'FHI',
       PETERBOROUGH: 'PFI',
     },
   },

--- a/test/fake-data/prisons.js
+++ b/test/fake-data/prisons.js
@@ -1,0 +1,13 @@
+const PRISONS = {
+  ADULT: {
+    MENS: {
+      LIVERPOOL: 'LPI',
+      PETERBOROUGH: 'PBI',
+    },
+    WOMENS: {
+      PETERBOROUGH: 'PFI',
+    },
+  },
+}
+
+module.exports = PRISONS

--- a/test/setup/database.js
+++ b/test/setup/database.js
@@ -1,0 +1,49 @@
+const path = require('path')
+
+const knexUnitTestConfig = {
+  client: 'pg',
+  connection: {
+    host: process.env.POSTGRES_HOSTNAME || 'localhost',
+    port: parseInt(process.env.POSTGRES_PORT, 10) || 5434,
+    user: 'form-builder-unit-tests',
+    password: 'form-builder-unit-tests',
+    database: 'form-builder-unit-tests',
+    ssl: false,
+  },
+  // debug: true,
+  migrations: {
+    directory: path.join(__dirname, '/../../migrations'),
+  },
+}
+const knex = require('knex')(knexUnitTestConfig)
+
+const migrate = async () => {
+  try {
+    // run knex migrations
+    await knex.migrate.latest()
+    // console.log('migration complete')
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err)
+  }
+}
+
+const rollback = async () => {
+  try {
+    // rollback knex migrations
+    await knex.migrate.rollback()
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err)
+  }
+}
+
+module.exports = {
+  knex,
+  setUp: async () => {
+    await migrate()
+  },
+  tearDown: async () => {
+    await rollback()
+  },
+}

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -1,0 +1,5 @@
+const database = require('./database')
+
+module.exports = {
+  database,
+}

--- a/test/setup/jest-setup.js
+++ b/test/setup/jest-setup.js
@@ -1,0 +1,4 @@
+const path = require('path')
+const dotenv = require('dotenv')
+
+dotenv.config({ path: path.join(__dirname, '/../../.env.unit-tests') })


### PR DESCRIPTION
This PR provides an approach to directly testing SQL queries against a test database. 

Comments below discuss various approaches to how that DB is created. One approach has been provided. 

The biggest change here is needing to define the `DB_PORT` which will impact all environments - though a default has been provided. This is because the existing knex setup does not factor in a DB port, and if going with a separate DB we cannot run two instances of Postgres on the same port (`5432` by default).

This may already suggest that a better approach is one DB with an `init` script. This is built into the Docker postgres image, but would mean recreating your DB environment - dump / restore if wanting to keep existing data. 

Typing this up, I'm already swaying towards an init script. 

**Edit** - init script approach PR - https://github.com/ministryofjustice/offender-categorisation/pull/691