### PR TITLE
[SI-108] Adds lite category button disabling JS - implementation only

### DIFF
--- a/assets/js/preventDoubleSubmit/index.js
+++ b/assets/js/preventDoubleSubmit/index.js
@@ -1,0 +1,15 @@
+;(() => {
+  'use strict'
+
+  const disableSubmitButtons = event => {
+    console.log('event', event.currentTarget)
+    event.currentTarget.querySelectorAll('button[data-prevent-double-click="true"]').forEach(button => {
+      button.dataset.clicked = 'true'
+      button.disabled = true
+      button.setAttribute('aria-disabled', 'true')
+      button.classList.add('govuk-button--disabled')
+    })
+  }
+
+  document.querySelectorAll('form').forEach(form => form.addEventListener('submit', disableSubmitButtons))
+})()

--- a/server/views/pages/liteCategories.html
+++ b/server/views/pages/liteCategories.html
@@ -130,3 +130,9 @@
 </div>
 
 {% endblock %}
+
+
+{% block bodyEnd %}
+{{ super() }}
+<script src="/assets/js/preventDoubleSubmit/index.js"></script>
+{% endblock %}


### PR DESCRIPTION
Implementation only as tests are more involved, requiring unmerged Cypress work - draft PR https://github.com/ministryofjustice/offender-categorisation/pull/718

The Gov UK front end components already include a piece of functionality to avoid double submits. The button for lite category submission is annotated with that attribute - https://github.com/ministryofjustice/offender-categorisation/blob/main/server/views/pages/liteCategories.html#L121-L124

This existing functionality works by debouncing / rate limiting the clicks to a maximum of 1 per second.

The problem experienced is that during longer unresponsive periods, the end users are clicking the submit button multiple times whilst the form is still submitting, but at longer durations than 1 second between clicks. This then creates multiple records in the DB - and can be reproduced by using Chrome's dev tools to throttle the connection to slow 3G and click multiple times.

This JS change will disable any annotated buttons (`data-prevent-double-click=true`) when clicked once.

This is a client side only fix. This will not prevent server side double submissions in any way.

This change has been restricted to only the lite categories page. 

