### PR TITLE
SI-465-Switch-Cat-Tool-to-non-deprecated-APIs

### DIFF
--- a/helm_deploy/offender-categorisation/templates/dlq-job.yaml
+++ b/helm_deploy/offender-categorisation/templates/dlq-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: dead-letter


### PR DESCRIPTION
Action Required from Service Teams - Kubernetes 1.25 Upgrade - Removing deprecated APIsAs part of the work to upgrade the Cloud Platform Kubernetes cluster from 1.24 to 1.25, a number of [deprecated APIs have to be removed](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25) from the manifests used to create kubernetes resources. Your team should have seen warnings of these deprecations already when deploying these resources either manually or through the pipeline.Below is the list of deprecated APIs linking to the guide explaining the changes that your team must make[batch/v1beta1 API of CronJob](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-cronjob-k8s-1-25.html)
[autoscaling/v2beta1 API version of HorizontalPodAutoscaler](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-hpa-k8s-1-25.html)
[policy/v1beta1 API version of PodDisruptionBudget](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-pdb-k8s-1-25.html)
[SI-465](https://dsdmoj.atlassian.net/browse/SI-465)

[SI-465]: https://dsdmoj.atlassian.net/browse/SI-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ