### PR TITLE
fix-feComponents-typo

### DIFF
--- a/server/views/partials/layout.html
+++ b/server/views/partials/layout.html
@@ -25,7 +25,7 @@
 <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
 <![endif]-->
 
-  {% if feComponents.jsInclude %}
+  {% if feComponents.jsIncludes %}
     {% for js in feComponents.jsIncludes %}
       <script src="{{ js }}" nonce="{{ cspNonce }}"></script>
     {% endfor %}


### PR DESCRIPTION
Fix the typo in `layout.html` that should say `if feComponents.jsIncludes` with an 's' on the end. JS currently not working in the app