### PR TITLE
SI-399-fix-hide-PII-titles-from-google-analytics

### DIFF
--- a/server/views/partials/layout.html
+++ b/server/views/partials/layout.html
@@ -6,13 +6,14 @@
 
 {% block head %}
   {% if googleAnalyticsKey | trim %}
+    {% set googleAnalyticsOptions = { title: '' } if googleAnalyticsHideTitle else {} %}
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsKey }}"></script>
     <script nonce="{{ cspNonce }}">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{ googleAnalyticsKey }}', {{ { title: '' } if googleAnalyticsHideTitle else {} }});
+      gtag('config', '{{ googleAnalyticsKey }}', {{ googleAnalyticsOptions | dump | safe }});
     </script>
   {% endif %}
 


### PR DESCRIPTION
Fix for dumping the nunjucks object for the google analytics title override.