### PR TITLE
SI-465-Switch-Cat-Tool-to-non-deprecated-APIs-generic-service-chart

### DIFF
--- a/helm_deploy/offender-categorisation/Chart.yaml
+++ b/helm_deploy/offender-categorisation/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.1
 
 dependencies:
   - name: generic-service
-    version: 2.1.0
+    version: 2.8
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.0


### PR DESCRIPTION
SI-465-Switch-Cat-Tool-to-non-deprecated-APIs-generic-service-chart. Move to using the latest version of the generic service chart (v2.8)