### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6.2.0
+  hmpps: ministryofjustice/hmpps@7
   browser-tools: circleci/browser-tools@1.4.4
 
 parameters:
@@ -37,8 +37,8 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-          - node_modules
-          - ~/.cache
+            - node_modules
+            - ~/.cache
       - run:
           name: Linter check
           command: npm run lint
@@ -48,19 +48,19 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-          - node_modules
-          - assets/stylesheets
+            - node_modules
+            - assets/stylesheets
   test:
     executor: builder
     steps:
-    - checkout
-    - restore_cache:
-        key: dependency-cache-{{ checksum "package-lock.json" }}
-    - run:
-        name: unit tests
-        command: npm run test
-    - store_test_results:
-        path: ./reports
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: unit tests
+          command: npm run test
+      - store_test_results:
+          path: ./reports
   integration_tests:
     working_directory: ~/app
     docker:
@@ -68,7 +68,7 @@ jobs:
         environment:
           RP_QUEUE_ACCESS_KEY_ID: 'dummy'
           RP_QUEUE_SECRET_ACCESS_KEY: 'dummy'
-          RP_DL_QUEUE_ACCESS_KEY_ID:  'dummy'
+          RP_DL_QUEUE_ACCESS_KEY_ID: 'dummy'
           RP_DL_QUEUE_SECRET_ACCESS_KEY: 'dummy'
           EVENT_QUEUE_ACCESS_KEY_ID: 'dummy'
           EVENT_QUEUE_SECRET_ACCESS_KEY: 'dummy'
@@ -111,7 +111,8 @@ jobs:
           name: Run the node app.
           command: npm start
           background: true
-      - hmpps/wait_till_ready: # Wait for node app to start
+      - hmpps/wait_till_ready:
+          # Wait for node app to start
           port: 3000
       - restore_cache:
           key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -188,7 +189,6 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
-
 workflows:
   version: 2
   build-test-and-deploy:
@@ -202,7 +202,7 @@ workflows:
             - build
       - integration_tests:
           requires:
-          - test
+            - test
       - integration_tests_cypress:
           requires:
             - test

--- a/helm_deploy/offender-categorisation/Chart.yaml
+++ b/helm_deploy/offender-categorisation/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.1
 
 dependencies:
   - name: generic-service
-    version: 2.1.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.0

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
 
   replicaCount: 2
@@ -11,7 +10,7 @@ generic-service:
 
   ingress:
     enable_allowlist: true
-    hosts: [dev.offender-categorisation.service.justice.gov.uk]
+    hosts: [ dev.offender-categorisation.service.justice.gov.uk ]
 
   env:
     ENVIRONMENT: dev
@@ -31,10 +30,5 @@ generic-service:
     ark-nps-hmcts-ttp3: 194.33.193.0/25
     ark-nps-hmcts-ttp4: 194.33.196.0/25
     ark-nps-hmcts-ttp5: 194.33.197.0/25
-    cloudplatform-live1-1: 35.178.209.113/32
-    cloudplatform-live1-2: 3.8.51.207/32
-    cloudplatform-live1-3: 35.177.252.54/32
-    health-kick: 35.177.252.195/32
-    global-protect: 35.176.93.186/32
-    mojvpn: 81.134.202.29/32
-    office: 217.33.148.210/32
+    groups:
+      - internal

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
 
   replicaCount: 4
@@ -11,7 +10,7 @@ generic-service:
 
   ingress:
     enable_allowlist: true
-    hosts: [preprod.offender-categorisation.service.justice.gov.uk]
+    hosts: [ preprod.offender-categorisation.service.justice.gov.uk ]
 
   env:
     ENVIRONMENT: preprod
@@ -27,46 +26,7 @@ generic-service:
     COMPONENT_API_URL: https://frontend-components-preprod.hmpps.service.justice.gov.uk
 
   allowlist:
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    global-protect: 35.176.93.186/32
-    petty-france-wifi: 213.121.161.112/28
-    cloudplatform-live1-1: 35.178.209.113/32
-    cloudplatform-live1-2: 3.8.51.207/32
-    cloudplatform-live1-3: 35.177.252.54/32
-    durham-tees-valley: 51.179.197.1/32
-    dxc_webproxy1: 195.92.38.20/32
-    dxc_webproxy2: 195.92.38.21/32
-    dxc_webproxy3: 195.92.38.22/32
-    dxc_webproxy4: 195.92.38.23/32
-    health-kick: 35.177.252.195/32
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    mojvpn: 81.134.202.29/32
-    oakwood-01: 217.161.76.184/29
-    oakwood-02: 217.161.76.192/29
-    oakwood-1: 217.161.76.187/32
-    oakwood-2: 217.161.76.195/32
-    oakwood-3: 217.161.76.186/32
-    oakwood-4: 217.161.76.194/32
-    office: 217.33.148.210/32
-    quantum1: 62.25.109.197/32
-    quantum2: 212.137.36.230/32
-    quantum3: 195.92.38.16/28
-    serco: 217.22.14.0/24
-    sodexo-northumberland2: 51.148.47.137/32
-    sodexo-northumberland: 88.98.48.10/32
-    sodexo-peterborough: 51.155.55.241/32
-    sodexo1: 80.86.46.16/32
-    sodexo2: 80.86.46.17/32
-    sodexo3: 80.86.46.18/32
-    sodexo4: 51.148.9.201
-    sodoxeo-forest-bank: 51.155.85.249/32
-
+    groups:
+      - internal
+      - prisons
+      - private_prisons

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
 
   replicaCount: 4
@@ -11,7 +10,7 @@ generic-service:
 
   ingress:
     enable_allowlist: true
-    hosts: [offender-categorisation.service.justice.gov.uk]
+    hosts: [ offender-categorisation.service.justice.gov.uk ]
 
   env:
     ENVIRONMENT: prod
@@ -27,60 +26,10 @@ generic-service:
     COMPONENT_API_URL: https://frontend-components.hmpps.service.justice.gov.uk
 
   allowlist:
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    cloudplatform-live1-1: 35.178.209.113/32
-    cloudplatform-live1-2: 3.8.51.207/32
-    cloudplatform-live1-3: 35.177.252.54/32
-    durham-tees-valley: 51.179.197.1/32
-    dxc_webproxy1: 195.92.38.20/32
-    dxc_webproxy2: 195.92.38.21/32
-    dxc_webproxy3: 195.92.38.22/32
-    dxc_webproxy4: 195.92.38.23/32
-    health-kick: 35.177.252.195/32
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    global-protect: 35.176.93.186/32
-    petty-france-wifi: 213.121.161.112/28
-    mojvpn: 81.134.202.29/32
-    oakwood-01: 217.161.76.184/29
-    oakwood-02: 217.161.76.192/29
-    oakwood-1: 217.161.76.187/32
-    oakwood-2: 217.161.76.195/32
-    oakwood-3: 217.161.76.186/32
-    oakwood-4: 217.161.76.194/32
-    office: 217.33.148.210/32
-    quantum1: 62.25.109.197/32
-    quantum2: 212.137.36.230/32
-    quantum3: 195.92.38.16/28
-    serco: 217.22.14.0/24
-    sodexo-northumberland2: 51.148.47.137/32
-    sodexo-northumberland: 88.98.48.10/32
-    sodexo-peterborough: 51.155.55.241/32
-    sodexo1: 80.86.46.16/32
-    sodexo2: 80.86.46.17/32
-    sodexo3: 80.86.46.18/32
-    sodexo4: 51.148.9.201
-    sodoxeo-forest-bank: 51.155.85.249/32
-    fivewells-1: "20.49.214.199/32"
-    fivewells-2: "20.49.214.228/32"
-    fivewells-3: "195.89.157.56/29"
-    fivewells-4: "195.59.215.184/29"
-    fivewells-5: "51.149.250.0/24"
-    fivewells-6: "51.149.249.0/29"
-    fivewells-7: "194.33.249.0/29"
-    fivewells-8: "51.149.249.32/29"
-    fivewells-9: "194.33.248.0/29"
-    azure-landing-zone-public-egress-1: "20.26.11.71/32"
-    azure-landing-zone-public-egress-2: "20.26.11.108/32"
-
+    groups:
+      - internal
+      - prisons
+      - private_prisons
   # determine which slack channel alerts are sent to, via the correct Alert Manager receiver
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `12 => 5 (7 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `42 => 0 (42 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- durham-tees-valley
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- health-kick
  

- quantum
  

- quantum_alt
  

- quantum3
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `48 => 0 (48 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- durham-tees-valley
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- health-kick
  

- quantum
  

- quantum_alt
  

- quantum3
  
