### PR TITLE
[SI-489] Removes npm cache left over from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN npm ci --no-audit && \
     npm run record-build-info
 
 RUN npm prune --no-audit --production
+RUN rm -rf /root/.cache
 
 ENV PORT=3000
 ENV NODE_ENV='production'


### PR DESCRIPTION
A hazard of not using a multi-stage build it seems