### PR TITLE
[SI-607] Log out prisoner booking IDs assumed needing removing from lite_category table

### DIFF
--- a/integration_tests/e2e/liteCategories.cy.ts
+++ b/integration_tests/e2e/liteCategories.cy.ts
@@ -271,6 +271,11 @@ describe('Lite Categories', () => {
         bookingIds: [11],
         startDates: ['28/01/2019'],
       })
+      cy.task('stubSentenceData', {
+        offenderNumbers: ['B2345YZ'],
+        bookingIds: [12],
+        startDates: ['2019-01-31'],
+      })
 
       cy.task('stubGetOffenderDetailsByOffenderNoList', {
         bookingId: [11, 12],
@@ -393,7 +398,12 @@ describe('Lite Categories', () => {
       cy.task('stubSentenceData', {
         offenderNumbers: ['B2345YZ'],
         bookingIds: [11],
-        startDates: [moment().toISOString(), moment().toISOString()],
+        startDates: [moment().toISOString()],
+      })
+      cy.task('stubSentenceData', {
+        offenderNumbers: ['B2345XY'],
+        bookingIds: [12],
+        startDates: ['28/03/2019'],
       })
       cy.task('stubGetUserDetails', { user: CATEGORISER_USER, caseloadId: 'SYI' })
       cy.task('stubGetStaffDetailsByUsernameList', { usernames: [SUPERVISOR_USER.username] })

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -1321,6 +1321,9 @@ describe('Lite', () => {
       },
     ])
 
+    const sentenceDates = [{ bookingId: 121, releaseDate: '2019-04-18' }]
+    prisonerSearchClient.getPrisonersByBookingIds.mockResolvedValue(sentenceDates)
+
     const data = await service.getUnapprovedLite(context, mockTransactionalClient)
 
     expect(data).toEqual([


### PR DESCRIPTION
The aim of this PR is not to actually remove the prisoners, but to list those who _would_ be removed, once the results have been manually verified. 