### PR TITLE
SI 151 store approved category comment in db

### DIFF
--- a/integration_tests/db/queries.ts
+++ b/integration_tests/db/queries.ts
@@ -57,6 +57,7 @@ export interface LiteCategoryDbRow {
   approved_placement_prison_id: string
   approved_placement_comment: string
   approved_comment: string
+  approved_category_comment: string
 }
 
 export interface NextReviewChangeHistoryDbRow {

--- a/integration_tests/e2e/liteCategories.cy.ts
+++ b/integration_tests/e2e/liteCategories.cy.ts
@@ -385,6 +385,7 @@ describe('Lite Categories', () => {
         expect(data.approved_placement_prison_id).eq('SYI')
         expect(data.approved_placement_comment).eq('approved placement comment')
         expect(data.approved_comment).eq('approved comment')
+        expect(data.approved_category_comment).eq('approved category comment')
       })
     })
   })
@@ -479,6 +480,7 @@ describe('Lite Categories', () => {
           approved_placement_prison_id: null,
           approved_placement_comment: null,
           approved_comment: null,
+          approved_category_comment: null
         },
       ])
 

--- a/migrations/20240408071312_add_approved_category_comment_to_lite_category.js
+++ b/migrations/20240408071312_add_approved_category_comment_to_lite_category.js
@@ -1,0 +1,9 @@
+exports.up = knex =>
+  knex.schema.alterTable('lite_category', table => {
+    table.string('approved_category_comment').nullable()
+  })
+
+exports.down = knex =>
+  knex.schema.table('lite_category', table => {
+    table.dropColumn('approved_category_comment')
+  })

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -516,6 +516,7 @@ module.exports = {
     approvedPlacement,
     approvedPlacementComment,
     approvedComment,
+    approvedCategoryComment,
     transactionalClient,
   }) {
     logger.info(`lite categorisation record for booking id ${bookingId} and user ${approvedBy}`)
@@ -528,7 +529,8 @@ module.exports = {
                  next_review_date             = $7,
                  approved_placement_prison_id = $8,
                  approved_placement_comment   = $9,
-                 approved_comment             = $10
+                 approved_comment             = $10,
+                 approved_category_comment    = $11
              where booking_id = $1
                and sequence = $2`,
       values: [
@@ -542,6 +544,7 @@ module.exports = {
         approvedPlacement,
         approvedPlacementComment,
         approvedComment,
+        approvedCategoryComment
       ],
     }
     return transactionalClient.query(query)

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -544,7 +544,7 @@ module.exports = {
         approvedPlacement,
         approvedPlacementComment,
         approvedComment,
-        approvedCategoryComment
+        approvedCategoryComment,
       ],
     }
     return transactionalClient.query(query)

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -343,6 +343,7 @@ module.exports = function createFormService(formClient) {
     approvedPlacement,
     approvedPlacementComment,
     approvedComment,
+    approvedCategoryComment,
     transactionalClient,
   }) {
     return formClient.approveLiteCategorisation({
@@ -357,6 +358,7 @@ module.exports = function createFormService(formClient) {
       approvedPlacement,
       approvedPlacementComment,
       approvedComment,
+      approvedCategoryComment,
       transactionalClient,
     })
   }

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -1417,6 +1417,7 @@ module.exports = function createOffendersService(
         approvedPlacement,
         approvedPlacementComment,
         approvedComment,
+        approvedCategoryComment,
         transactionalClient,
       })
       return nomisClient.createSupervisorApproval({

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -1239,6 +1239,7 @@ describe('Lite', () => {
       approvedPlacement: 'BMI',
       approvedPlacementComment: 'approvedPlacementComment',
       approvedComment: 'approvedComment',
+      approvedCategoryComment: 'approvedCategoryComment',
       transactionalClient: mockTransactionalClient,
     })
     expect(nomisClient.createSupervisorApproval).toBeCalledWith({


### PR DESCRIPTION
It was noticed that approvedCategoryComment wasn't being stored in the database, this PR adds a column to the lite category table to store this field alongside the other form data from that submit.