### PR TITLE
added in redirection to sign-out when getting a 401

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -231,6 +231,8 @@ module.exports = function createApp({
         if (err) return next(err)
         return req.session.destroy(() => res.redirect(authLogoutUrl))
       })
+    } else {
+      res.redirect(authLogoutUrl)
     }
   })
 

--- a/server/errorHandler.js
+++ b/server/errorHandler.js
@@ -8,6 +8,11 @@ module.exports =
   (error, req, res, next) => {
     logger.error(error)
 
+    if (error.status === 401) {
+      logger.info('Logging user out')
+      return res.redirect('/sign-out')
+    }
+
     // code to handle unknown errors
     const prodMessage = `Something went wrong at ${moment()}. The error has been logged. Please try again`
     res.locals.message = production ? prodMessage : error.message


### PR DESCRIPTION
Redirecting to the signout page when it is a 401 plus including a logout of auth when there is no user, taken from the way other apps in the estate are handling this.