### PR TITLE
Bug/si 942 moic 404s

### DIFF
--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -152,9 +152,8 @@ module.exports = function createOffendersService(
         .filter(o => !o.dbRecord || !o.dbRecord.catType || o.dbRecord.catType === CatType.INITIAL.name)
         .map(o => o.bookingId)
 
-      const [prisoners, pomMap, securityReferredOffenders] = await Promise.all([
+      const [prisoners, securityReferredOffenders] = await Promise.all([
         prisonerSearchClient.getPrisonersByBookingIds(bookingIds),
-        getPomMap(combined, allocationClient),
         formService.getSecurityReferrals(agencyId, transactionalDbClient),
       ])
 
@@ -185,8 +184,11 @@ module.exports = function createOffendersService(
       // trim db results to only those not in the Nomis-derived list
       const dbInProgressFiltered = dbManualInProgress.filter(d => !nomisFiltered.some(n => d.bookingId === n.bookingId))
 
+      const allRecords = [...nomisFiltered, ...dbInProgressFiltered]
+      const pomMap = getPomMap(allRecords, allocationClient)
+
       const decoratedResults = await Promise.all(
-        [...nomisFiltered, ...dbInProgressFiltered].map(async raw => {
+        allRecords.map(async raw => {
           const nomisRecord = raw.lastName ? raw : await nomisClient.getBasicOffenderDetails(raw.bookingId)
           const dbRecord = raw.lastName
             ? await formService.getCategorisationRecord(raw.bookingId, transactionalDbClient)

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -185,7 +185,7 @@ module.exports = function createOffendersService(
       const dbInProgressFiltered = dbManualInProgress.filter(d => !nomisFiltered.some(n => d.bookingId === n.bookingId))
 
       const allRecords = [...nomisFiltered, ...dbInProgressFiltered]
-      const pomMap = getPomMap(allRecords, allocationClient)
+      const pomMap = await getPomMap(allRecords, allocationClient)
 
       const decoratedResults = await Promise.all(
         allRecords.map(async raw => {


### PR DESCRIPTION
To reduce (but not eliminate) the number of 404s from MOIC (also called allocation manager) by only querying the offenders which are actually going to be shown on the page (i.e. post all the filtering).

This will mean the moic calls will no longer be done in parallel with 2 other calls (prisoner search and get security referrals), however it will also reduce the number of calls being made to moic (it does them in batches of 20 at a time) so it should be a net reduction in time. On dev, it reduced the calls from 692 -> 253 for one page load, and reduced the 404s from 297 to 64.