### PR TITLE
[SI-1091] Delete pending cats on Offender Release event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ main_branch: &main_branch
 
 orbs:
   hmpps: ministryofjustice/hmpps@8
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.8
 
 parameters:
   node-version:
@@ -106,11 +106,6 @@ jobs:
       - hmpps/install_aws_cli
       - checkout
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          # TODO remove following line when fixed https://github.com/CircleCI-Public/browser-tools-orb/issues/90
-          chrome-version: 116.0.5845.96
-      #- browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - attach_workspace:
           at: ~/app
       - hmpps/wait_till_ready # Wait for localstack to start before creating resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
       - hmpps/install_aws_cli
       - checkout
       - run: sudo apt-get update
+      - browser-tools/install-chromedriver
       - attach_workspace:
           at: ~/app
       - hmpps/wait_till_ready # Wait for localstack to start before creating resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,15 @@ jobs:
     working_directory: ~/app
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
+        environment:
+          RP_QUEUE_ACCESS_KEY_ID: 'dummy'
+          RP_QUEUE_SECRET_ACCESS_KEY: 'dummy'
+          RP_DL_QUEUE_ACCESS_KEY_ID: 'dummy'
+          RP_DL_QUEUE_SECRET_ACCESS_KEY: 'dummy'
+          EVENT_QUEUE_ACCESS_KEY_ID: 'dummy'
+          EVENT_QUEUE_SECRET_ACCESS_KEY: 'dummy'
+          EVENT_DL_QUEUE_ACCESS_KEY_ID: 'dummy'
+          EVENT_DL_QUEUE_SECRET_ACCESS_KEY: 'dummy'
       - image: cimg/postgres:14.3
         environment:
           POSTGRES_USER: form-builder
@@ -183,6 +192,15 @@ jobs:
           name: Run wiremock
           command: java -jar wiremock.jar --port 9091
           background: true
+      - hmpps/wait_till_ready # Wait for localstack to start before creating resources
+      - run:
+          name: Create localstack queues
+          command: |
+            export AWS_PAGER=""
+            aws --endpoint-url http://localhost:4566 --region eu-west-2 sqs create-queue --queue-name event
+            aws --endpoint-url http://localhost:4566 --region eu-west-2 sqs create-queue --queue-name risk_profiler_change
+            aws --endpoint-url http://localhost:4566 --region eu-west-2 sqs create-queue --queue-name event_dlq
+            aws --endpoint-url http://localhost:4566 --region eu-west-2 sqs create-queue --queue-name risk_profiler_change_dlq
       - run:
           name: Run the node app.
           command: npm run start-feature

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
       - hmpps/install_aws_cli
       - checkout
       - run: sudo apt-get update
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - attach_workspace:
           at: ~/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
           TMP_DIR: /private
           AWS_DEFAULT_REGION: eu-west-2
     steps:
+      - hmpps/install_aws_cli
       - checkout
       - attach_workspace:
           at: ~/app

--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@ DB_USER=form-builder
 DB_PASS=form-builder
 DB_SERVER=0.0.0.0
 DB_NAME=form-builder
-SQS_ENABLED=false
+SQS_ENABLED=true
 NOMIS_AUTH_URL=http://localhost:9090/auth
 NOMIS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import mockApis from './integration_tests/mockApis'
+import mockEvents from './integration_tests/events'
 import db from './integration_tests/db'
 
 export default defineConfig({
@@ -19,6 +20,7 @@ export default defineConfig({
       on('task', {
         reset: resetStubs,
         ...mockApis,
+        ...mockEvents,
         ...db,
       })
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     - NODE_ENV=development
 
   form-db:
-    image: postgres
+    image: postgres:15
     networks:
     - hmpps
     container_name: form-builder-db

--- a/feature.env
+++ b/feature.env
@@ -2,7 +2,7 @@ DB_USER=form-builder
 DB_PASS=form-builder
 DB_SERVER=0.0.0.0
 DB_NAME=form-builder
-SQS_ENABLED=false
+SQS_ENABLED=true
 
 PORT=3007
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
@@ -21,3 +21,4 @@ RISK_PROFILER_ENDPOINT_URL=http://localhost:9091/risk-profiler/
 INGRESS_URL=http://localhost:9091/ingress
 DPS_URL=http://localhost:9091/dps
 COMPONENT_API_URL=http://localhost:9091/components
+FEATURE_FLAG__EVENT__DELETE_PENDING_RECATS=true

--- a/integration_tests/e2e/events.cy.ts
+++ b/integration_tests/e2e/events.cy.ts
@@ -12,6 +12,21 @@ describe('Events', () => {
   })
 
   describe('prisoner-offender-search.prisoner.released', () => {
+    it('should do nothing with release events when the "reason" is not "RELEASED"', () => {
+      dbSeeder(mensUnapprovedInitialCategorisationSeedData())
+      cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 10000 }, (data: DbQueryResult) => {
+        cy.log('Result: ', data.rowCount)
+        return data.rowCount === 12
+      })
+
+      cy.task('sendPrisonerReleasedMessage', { nomsNumber: 'B0010XY', reason: 'TRANSFER' }).then(() => {
+        cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 10000 }, (data: DbQueryResult) => {
+          cy.log('Result: ', data.rowCount)
+          return data.rowCount === 12
+        })
+      })
+    })
+
     it('should delete any unapproved initial categorisations for a given bookingId', () => {
       dbSeeder(mensUnapprovedInitialCategorisationSeedData())
       cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 10000 }, (data: DbQueryResult) => {

--- a/integration_tests/e2e/events.cy.ts
+++ b/integration_tests/e2e/events.cy.ts
@@ -1,0 +1,73 @@
+import dbSeeder, { dbSeederLiteCategory } from '../fixtures/db-seeder'
+import mensUnapprovedInitialCategorisationSeedData from '../fixtures/events/mensUnapprovedInitialCategorisationSeedData'
+import mensUnapprovedRecategorisationSeedData from '../fixtures/events/mensUnapprovedRecategorisationSeedData'
+import mensUnapprovedLiteCategorisationSeedData from '../fixtures/events/mensUnapprovedLiteCategorisationSeedData'
+
+type DbQueryResult = { rowCount: number; rows: any[] }
+
+describe('Events', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('setUpDb')
+  })
+
+  describe('prisoner-offender-search.prisoner.released', () => {
+    it('should delete any unapproved initial categorisations for a given bookingId', () => {
+      dbSeeder(mensUnapprovedInitialCategorisationSeedData())
+      cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 10000 }, (data: DbQueryResult) => {
+        cy.log('Result: ', data.rowCount)
+        return data.rowCount === 12
+      })
+
+      cy.task('sendPrisonerReleasedMessage', { nomsNumber: 'B0010XY' }).then(() => {
+        cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 10000 }, (data: DbQueryResult) => {
+          cy.log('Result: ', data.rowCount)
+          const expectedRemainingSequenceNumbers = [8, 10, 11, 12]
+          const allRemain = data.rows.every(row =>
+            expectedRemainingSequenceNumbers.some(seq_no => seq_no === row.sequence_no)
+          )
+          return data.rowCount === expectedRemainingSequenceNumbers.length && allRemain
+        })
+      })
+    })
+
+    it('should delete any unapproved recategorisations for a given bookingId', () => {
+      dbSeeder(mensUnapprovedRecategorisationSeedData())
+      cy.assertDBWithRetries(
+        'selectFormTableDbRow',
+        { bookingId: 20000 },
+        (rows: DbQueryResult) => rows.rowCount === 12
+      )
+
+      cy.task('sendPrisonerReleasedMessage', { nomsNumber: 'B0011XY' }).then(() => {
+        cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 20000 }, (data: DbQueryResult) => {
+          cy.log('Result: ', data.rowCount)
+          const expectedRemainingSequenceNumbers = [8, 10, 11, 12]
+          const allRemain = data.rows.every(row =>
+            expectedRemainingSequenceNumbers.some(seq_no => seq_no === row.sequence_no)
+          )
+          return data.rowCount === expectedRemainingSequenceNumbers.length && allRemain
+        })
+      })
+    })
+
+    it('should delete any unapproved lite categorisations for a given bookingId', () => {
+      dbSeederLiteCategory(mensUnapprovedLiteCategorisationSeedData())
+      cy.assertDBWithRetries('getLiteData', { bookingId: 30000 }, (data: DbQueryResult) => {
+        cy.log('Result: ', data.rowCount)
+        return data.rowCount === 6
+      })
+
+      cy.task('sendPrisonerReleasedMessage', { nomsNumber: 'B2345YZ' }).then(() => {
+        cy.assertDBWithRetries('getLiteData', { bookingId: 30000 }, (data: DbQueryResult) => {
+          cy.log('Result: ', data.rowCount)
+          const expectedRemainingSequenceNumbers = [3, 4, 6]
+          const allRemain = data.rows.every(row =>
+            expectedRemainingSequenceNumbers.some(seq_no => seq_no === row.sequence)
+          )
+          return data.rowCount === expectedRemainingSequenceNumbers.length && allRemain
+        })
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/liteCategories.cy.ts
+++ b/integration_tests/e2e/liteCategories.cy.ts
@@ -9,7 +9,7 @@ import Page from '../pages/page'
 import ErrorPage from '../pages/error/error'
 import CategoriserHomePage from '../pages/categoriser/home'
 import SupervisorDashboardHomePage from '../pages/dashboard/supervisor/home'
-import dbSeeder, { dbSeederLiteCategory } from '../fixtures/db-seeder'
+import { dbSeederLiteCategory } from '../fixtures/db-seeder'
 import { supervisorViewSeedData } from '../fixtures/liteCategoriser/supervisorView'
 import LiteCategoriesApprovalPage from '../pages/liteCategories/approval'
 import { unapprovedLiteCategorisation } from '../fixtures/liteCategoriser/unapprovedLiteCategorisation'
@@ -480,7 +480,7 @@ describe('Lite Categories', () => {
           approved_placement_prison_id: null,
           approved_placement_comment: null,
           approved_comment: null,
-          approved_category_comment: null
+          approved_category_comment: null,
         },
       ])
 

--- a/integration_tests/events/index.ts
+++ b/integration_tests/events/index.ts
@@ -15,7 +15,6 @@ const eventParamsWith = body => {
 }
 
 const sendMessage = message => {
-  console.log('send message', message)
   sqs.sendMessage(message, (err, data) => {
     if (err) {
       // eslint-disable-next-line no-console

--- a/integration_tests/events/index.ts
+++ b/integration_tests/events/index.ts
@@ -1,0 +1,55 @@
+import AWS from 'aws-sdk'
+import config from '../../server/config'
+
+AWS.config.update({
+  region: 'eu-west-2',
+})
+
+const sqs = new AWS.SQS()
+
+const eventParamsWith = body => {
+  return {
+    ...(body && { MessageBody: JSON.stringify(body) }),
+    QueueUrl: config.sqs.event.queueUrl,
+  }
+}
+
+const sendMessage = message => {
+  console.log('send message', message)
+  sqs.sendMessage(message, (err, data) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error', err)
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('Successfully added message', data.MessageId)
+    }
+  })
+  return null
+}
+
+const createPrisonerReleasedMessage = (nomsNumber: string, reason = 'RELEASED') => {
+  return {
+    Type: 'Notification',
+    MessageId: 'fake-message-id',
+    TopicArn: 'arn:aws:sns:fake',
+    Message: `{"additionalInformation":{"nomsNumber":"${nomsNumber}","reason":"${reason}","prisonId":"WTI"},"occurredAt":"2024-07-25T07:57:37.883940701+01:00","eventType":"prisoner-offender-search.prisoner.released","version":1,"description":"A prisoner has been released from a prison with reason: released on temporary absence","detailUrl":"https://prisoner-search.prison.service.justice.gov.uk/prisoner/${nomsNumber}"}`,
+    Timestamp: '2024-07-25T06:57:39.938Z',
+    SignatureVersion: '1',
+    Signature: 'fakesig',
+    SigningCertURL: 'https://some.pem',
+    UnsubscribeURL: 'https://fake.url',
+    MessageAttributes: {
+      traceparent: { Type: 'String', Value: 'a-guid' },
+      eventType: { Type: 'String', Value: 'prisoner-offender-search.prisoner.released' },
+    },
+  }
+}
+
+const sendPrisonerReleasedMessage = ({ nomsNumber, reason = 'RELEASED' }) => {
+  return sendMessage(eventParamsWith(createPrisonerReleasedMessage(nomsNumber, reason)))
+}
+
+export default {
+  sendPrisonerReleasedMessage,
+}

--- a/integration_tests/fixtures/events/mensUnapprovedInitialCategorisationSeedData.ts
+++ b/integration_tests/fixtures/events/mensUnapprovedInitialCategorisationSeedData.ts
@@ -1,0 +1,67 @@
+type Categorisation = {
+  id: number
+  booking_id: number
+  status: string
+  sequence_no: number
+}
+
+const createInitialCat = ({ id, booking_id, status, sequence_no }: Categorisation) => ({
+  id,
+  form_response: {
+    ratings: { securityInput: null },
+    supervisor: { review: null },
+    categoriser: { provisionalCategory: { suggestedCategory: 'C', overriddenCategory: null } },
+  },
+  booking_id,
+  user_id: 'null',
+  status,
+  assigned_user_id: 'CATEGORISER_USER',
+  referred_date: null,
+  referred_by: 'null',
+  sequence_no,
+  risk_profile: {},
+  prison_id: 'LEI',
+  offender_no: 'B0010XY',
+  start_date: '2019-07-01 00:00:00.000000 +00:00',
+  security_reviewed_by: 'null',
+  security_reviewed_date: null,
+  approval_date: null,
+  cat_type: 'INITIAL',
+  nomis_sequence_no: null,
+  assessment_date: '2019-07-22',
+  approved_by: null,
+  assessed_by: null,
+  review_reason: 'DUE',
+  due_by_date: '2019-08-03',
+  cancelled_date: null,
+  cancelled_by: null,
+})
+
+export default function mensUnapprovedInitialCategorisationSeedData() {
+  // still 'good enough' not to delete
+  const approvedCatMissingApprovalDate = {
+    ...createInitialCat({ id: -10010, booking_id: 10000, status: 'UNCATEGORISED', sequence_no: 11 }),
+    approval_date: '2024-02-02 09:04:15.600000 +00:00',
+  }
+
+  // still 'good enough' not to delete
+  const approvedCatMissingApprovedBy = {
+    ...createInitialCat({ id: -10011, booking_id: 10000, status: 'SUPERVISOR_BACK', sequence_no: 12 }),
+    approved_by: 'SOME_VALUE_HERE',
+  }
+
+  return [
+    createInitialCat({ id: -10000, booking_id: 10000, status: 'UNCATEGORISED', sequence_no: 1 }),
+    createInitialCat({ id: -10001, booking_id: 10000, status: 'STARTED', sequence_no: 2 }),
+    createInitialCat({ id: -10002, booking_id: 10000, status: 'SECURITY_MANUAL', sequence_no: 3 }),
+    createInitialCat({ id: -10003, booking_id: 10000, status: 'SECURITY_AUTO', sequence_no: 4 }),
+    createInitialCat({ id: -10004, booking_id: 10000, status: 'SECURITY_FLAGGED', sequence_no: 5 }),
+    createInitialCat({ id: -10005, booking_id: 10000, status: 'SECURITY_BACK', sequence_no: 6 }),
+    createInitialCat({ id: -10006, booking_id: 10000, status: 'AWAITING_APPROVAL', sequence_no: 7 }),
+    createInitialCat({ id: -10007, booking_id: 10000, status: 'APPROVED', sequence_no: 8 }),
+    createInitialCat({ id: -10008, booking_id: 10000, status: 'SUPERVISOR_BACK', sequence_no: 9 }),
+    createInitialCat({ id: -10009, booking_id: 10000, status: 'CANCELLED', sequence_no: 10 }),
+    approvedCatMissingApprovalDate,
+    approvedCatMissingApprovedBy,
+  ]
+}

--- a/integration_tests/fixtures/events/mensUnapprovedLiteCategorisationSeedData.ts
+++ b/integration_tests/fixtures/events/mensUnapprovedLiteCategorisationSeedData.ts
@@ -1,0 +1,57 @@
+import { LiteCategoryDbRow } from '../../db/queries'
+
+type LiteCat = {
+  booking_id: number
+  sequence: number
+}
+
+const createLiteCategorisation = ({ booking_id, sequence }: LiteCat): LiteCategoryDbRow => ({
+  booking_id,
+  sequence,
+  category: 'V',
+  supervisor_category: null,
+  offender_no: 'B2345YZ',
+  prison_id: 'LEI',
+  created_date: '2023-06-26 09:04:15.600000 +00:00',
+  approved_date: null,
+  assessed_by: 'CATEGORISER_USER',
+  approved_by: null,
+  assessment_committee: '',
+  assessment_comment: null,
+  next_review_date: '2024-06-26 09:04:15.600000 +00:00',
+  placement_prison_id: null,
+  approved_committee: null,
+  approved_placement_prison_id: null,
+  approved_placement_comment: null,
+  approved_comment: null,
+  approved_category_comment: null,
+})
+
+export default function mensUnapprovedLiteCategorisationSeedData(): LiteCategoryDbRow[] {
+  const approvedLiteCat = {
+    ...createLiteCategorisation({ booking_id: 30000, sequence: 3 }),
+    approved_by: 'FAKE_TEST',
+    approved_date: '2024-01-01 09:04:15.600000 +00:00',
+  }
+
+  // still 'good enough' not to delete
+  const approvedLiteCatMissingApprovedDate = {
+    ...createLiteCategorisation({ booking_id: 30000, sequence: 4 }),
+    approved_date: '2024-02-02 09:04:15.600000 +00:00',
+  }
+
+  // still 'good enough' not to delete
+  const approvedLiteCatMissingApprovalBy = {
+    ...createLiteCategorisation({ booking_id: 30000, sequence: 6 }),
+    approved_by: 'JOE_JONES',
+  }
+
+  return [
+    createLiteCategorisation({ booking_id: 30000, sequence: 1 }),
+    createLiteCategorisation({ booking_id: 30000, sequence: 2 }),
+    approvedLiteCat,
+    approvedLiteCatMissingApprovedDate,
+    createLiteCategorisation({ booking_id: 30000, sequence: 5 }),
+    approvedLiteCatMissingApprovalBy,
+  ]
+}

--- a/integration_tests/fixtures/events/mensUnapprovedRecategorisationSeedData.ts
+++ b/integration_tests/fixtures/events/mensUnapprovedRecategorisationSeedData.ts
@@ -1,0 +1,63 @@
+type Recategorisation = {
+  id: number
+  booking_id: number
+  status: string
+  sequence_no: number
+}
+
+const createRecat = ({ id, booking_id, status, sequence_no }: Recategorisation) => ({
+  id,
+  form_response: { recat: { decision: { category: 'B' }, securityInput: null }, supervisor: { review: null } },
+  booking_id,
+  user_id: 'null',
+  status,
+  assigned_user_id: 'RECATEGORISER_USER',
+  referred_date: null,
+  referred_by: 'null',
+  sequence_no,
+  risk_profile: {},
+  prison_id: 'LEI',
+  offender_no: 'B0011XY',
+  start_date: '2019-07-01 00:00:00.000000 +00:00',
+  security_reviewed_by: 'null',
+  security_reviewed_date: null,
+  approval_date: null,
+  cat_type: 'RECAT',
+  nomis_sequence_no: null,
+  assessment_date: '2019-07-22',
+  approved_by: null,
+  assessed_by: null,
+  review_reason: 'DUE',
+  due_by_date: '2019-08-03',
+  cancelled_date: null,
+  cancelled_by: null,
+})
+
+export default function mensUnapprovedInitialCategorisationSeedData() {
+  // still 'good enough' not to delete
+  const approvedRecatMissingApprovalDate = {
+    ...createRecat({ id: -20010, booking_id: 20000, status: 'SECURITY_BACK', sequence_no: 11 }),
+    approval_date: '2024-02-02 09:04:15.600000 +00:00',
+  }
+
+  // still 'good enough' not to delete
+  const approvedRecatMissingApprovedBy = {
+    ...createRecat({ id: -20011, booking_id: 20000, status: 'SECURITY_FLAGGED', sequence_no: 12 }),
+    approved_by: 'SOME_VALUE_HERE',
+  }
+
+  return [
+    createRecat({ id: -20000, booking_id: 20000, status: 'UNCATEGORISED', sequence_no: 1 }),
+    createRecat({ id: -20001, booking_id: 20000, status: 'STARTED', sequence_no: 2 }),
+    createRecat({ id: -20002, booking_id: 20000, status: 'SECURITY_MANUAL', sequence_no: 3 }),
+    createRecat({ id: -20003, booking_id: 20000, status: 'SECURITY_AUTO', sequence_no: 4 }),
+    createRecat({ id: -20004, booking_id: 20000, status: 'SECURITY_FLAGGED', sequence_no: 5 }),
+    createRecat({ id: -20005, booking_id: 20000, status: 'SECURITY_BACK', sequence_no: 6 }),
+    createRecat({ id: -20006, booking_id: 20000, status: 'AWAITING_APPROVAL', sequence_no: 7 }),
+    createRecat({ id: -20007, booking_id: 20000, status: 'APPROVED', sequence_no: 8 }),
+    createRecat({ id: -20008, booking_id: 20000, status: 'SUPERVISOR_BACK', sequence_no: 9 }),
+    createRecat({ id: -20009, booking_id: 20000, status: 'CANCELLED', sequence_no: 10 }),
+    approvedRecatMissingApprovalDate,
+    approvedRecatMissingApprovedBy,
+  ]
+}

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -35,5 +35,15 @@ declare namespace Cypress {
      * @example cy.stubLogin({ user: SUPERVISOR_USER })
      */
     stubLogin({ user: UserAccount }): Chainable<AUTWindow>
+
+    /**
+     * Custom command to assert a database condition is met, retrying the assertion X times.
+     * @param task The name of the Cypress task to run.
+     * @param arg The argument to pass to the task.
+     * @param assertionFn The assertion function.
+     * @param retries Number of retries to perform. Default is 10.
+     * @param delay Delay between retries in milliseconds. Default is 500ms.
+     */
+    assertDBWithRetries(task: string, arg: any, assertionFn: (result: any) => boolean, retries?: number, delay?: number): Chainable<boolean>;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "audit-ci": "^6.6.1",
         "concurrently": "^8.2.2",
         "cookie-session": "^2.0.0",
-        "cypress": "^13.8.0",
+        "cypress": "^13.13.1",
         "cypress-multi-reporters": "^1.6.4",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -4015,9 +4015,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.8.0.tgz",
-      "integrity": "sha512-Qau//mtrwEGOU9cn2YjavECKyDUwBh8J2tit+y9s1wsv6C3BX+rlv6I9afmQnL8PmEEzJ6be7nppMHacFzZkTw==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
+      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4060,7 +4060,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -10999,15 +10999,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "audit-ci": "^6.6.1",
     "concurrently": "^8.2.2",
     "cookie-session": "^2.0.0",
-    "cypress": "^13.8.0",
+    "cypress": "^13.13.1",
     "cypress-multi-reporters": "^1.6.4",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/server/config.js
+++ b/server/config.js
@@ -164,4 +164,13 @@ module.exports = {
   )}`,
   https: production,
   productId: get('PRODUCT_ID', 'UNASSIGNED', true, { requireInProduction: true }),
+  featureFlags: {
+    events: {
+      offender_release: {
+        enable_pending_categorisation_deletion: get('FEATURE_FLAG__EVENT__DELETE_PENDING_RECATS', 'false', true, {
+          requireInProduction: false,
+        }),
+      },
+    },
+  },
 }

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -585,4 +585,49 @@ module.exports = {
     }
     return transactionalClient.query(query)
   },
+
+  getPendingCategorisations(offenderNo, transactionalClient) {
+    logger.info(`get pending categorisations for offenderNo ${offenderNo}`)
+    const query = {
+      text: `select f.id, f.booking_id, f.status, f.cat_type
+             from form f
+             where f.offender_no = $1
+             and f.approval_date is null
+             and f.approved_by is null
+             and f.status in (
+                '${Status.UNCATEGORISED.name}',
+                '${Status.STARTED.name}',
+                '${Status.SECURITY_MANUAL.name}',
+                '${Status.SECURITY_AUTO.name}',
+                '${Status.SECURITY_FLAGGED.name}',
+                '${Status.SECURITY_BACK.name}',
+                '${Status.AWAITING_APPROVAL.name}',
+                '${Status.SUPERVISOR_BACK.name}'
+             );`,
+      values: [offenderNo],
+    }
+    return transactionalClient.query(query)
+  },
+
+  getPendingLiteCategorisations(offenderNo, transactionalClient) {
+    logger.info(`get pending lite categorisations for offenderNo ${offenderNo}`)
+    const query = {
+      text: `select lc.booking_id, lc.sequence
+             from public.lite_category lc
+             where lc.offender_no = $1
+             and lc.approved_date is null
+             and lc.approved_by is null;`,
+      values: [offenderNo],
+    }
+    return transactionalClient.query(query)
+  },
+
+  deleteCategorisation(categorisationId, transactionalClient) {
+    logger.info(`deleting categorisation record ${categorisationId}`)
+    const query = {
+      text: `delete from form f where f.id=$1`,
+      values: [categorisationId],
+    }
+    return transactionalClient.query(query)
+  },
 }

--- a/server/services/sqsService.js
+++ b/server/services/sqsService.js
@@ -115,7 +115,7 @@ module.exports = function createSqsService(offenderService, formService) {
             }
             const reason = event?.additionalInformation?.reason
             if (!reason || reason !== 'RELEASED') {
-              logger.warn({ MessageId: message.MessageId, nomsNumber }, 'Reason was not "RELEASED"')
+              logger.info({ MessageId: message.MessageId, nomsNumber }, 'Reason was not "RELEASED"')
               break
             }
             await formService.deletePendingCategorisations(nomsNumber, transactionalDbClient)

--- a/server/services/sqsService.js
+++ b/server/services/sqsService.js
@@ -4,6 +4,7 @@ const logger = require('../../log')
 const config = require('../config')
 const riskChangeHelper = require('../utils/riskChange')
 const db = require('../data/dataAccess/db')
+const { events } = require('../utils/eventUtils')
 
 AWS.config.update({
   region: 'eu-west-2',
@@ -102,9 +103,19 @@ module.exports = function createSqsService(offenderService, formService) {
               await offenderService.checkAndMergeOffenderNo(context, bookingId, transactionalDbClient)
             }
             break
-          case 'DATA_COMPLIANCE_DELETE-OFFENDER':
-            // TODO
+          case events.EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED: {
+            logger.info(
+              { event },
+              `${events.EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED}: Received payload`
+            )
+            const nomsNumber = event?.additionalInformation?.nomsNumber
+            if (!nomsNumber) {
+              logger.warn({ MessageId: message.MessageId }, 'MessageId was missing a nomsNumber')
+              break
+            }
+            await formService.deletePendingCategorisations(nomsNumber, transactionalDbClient)
             break
+          }
           case 'EXTERNAL_MOVEMENT_RECORD-INSERTED':
             {
               const { bookingId, offenderIdDisplay, movementType, fromAgencyLocationId, toAgencyLocationId } = event

--- a/server/services/sqsService.js
+++ b/server/services/sqsService.js
@@ -113,6 +113,11 @@ module.exports = function createSqsService(offenderService, formService) {
               logger.warn({ MessageId: message.MessageId }, 'MessageId was missing a nomsNumber')
               break
             }
+            const reason = event?.additionalInformation?.reason
+            if (!reason || reason !== 'RELEASED') {
+              logger.warn({ MessageId: message.MessageId, nomsNumber }, 'Reason was not "RELEASED"')
+              break
+            }
             await formService.deletePendingCategorisations(nomsNumber, transactionalDbClient)
             break
           }

--- a/server/utils/eventUtils.js
+++ b/server/utils/eventUtils.js
@@ -58,4 +58,8 @@ const transferDlqEventMessages = async ({ sqs, sqsDlq, sqsQueueUrl, sqsDlqQueueU
   }
 }
 
-module.exports = { transferDlqEventMessages }
+const events = {
+  EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED: 'prisoner-offender-search.prisoner.released',
+}
+
+module.exports = { transferDlqEventMessages, events }

--- a/test/data/formClient.test.js
+++ b/test/data/formClient.test.js
@@ -1,7 +1,6 @@
 const moment = require('moment')
 const formClient = require('../../server/data/formClient')
 const RiskChangeStatus = require('../../server/utils/riskChangeStatusEnum')
-const Status = require('../../server/utils/statusEnum')
 
 const mockTransactionalClient = { query: jest.fn(), release: jest.fn() }
 

--- a/test/services/sqsService.test.js
+++ b/test/services/sqsService.test.js
@@ -1,5 +1,6 @@
 const serviceCreator = require('../../server/services/sqsService')
 const db = require('../../server/data/dataAccess/db')
+const { events } = require('../../server/utils/eventUtils')
 
 const mockTransactionalClient = { query: jest.fn(), release: jest.fn() }
 db.pool.connect = jest.fn()
@@ -12,6 +13,7 @@ const offendersService = {
 
 const formService = {
   createRiskChange: jest.fn(),
+  deletePendingCategorisations: jest.fn(),
 }
 
 let service
@@ -127,5 +129,47 @@ describe('eventQueueConsumer', () => {
     expect(offendersService.handleExternalMovementEvent.mock.calls[0][4]).toEqual('FROM')
     expect(offendersService.handleExternalMovementEvent.mock.calls[0][5]).toEqual('TO')
     expect(offendersService.handleExternalMovementEvent.mock.calls[0][6]).toEqual(mockTransactionalClient)
+  })
+
+  describe(`${events.EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED} event handler`, () => {
+    const offenderId = 'T123456'
+
+    const createPrisonerReleasedMessage = (nomsNumber, reason = 'RELEASED') => {
+      return {
+        Body: JSON.stringify({
+          Type: 'Notification',
+          MessageId: 'fake-message-id',
+          TopicArn: 'arn:aws:sns:fake',
+          Message: `{"additionalInformation":{"nomsNumber":"${nomsNumber}","reason":"${reason}","prisonId":"WTI"},"occurredAt":"2024-07-25T07:57:37.883940701+01:00","eventType":"prisoner-offender-search.prisoner.released","version":1,"description":"A prisoner has been released from a prison with reason: released on temporary absence","detailUrl":"https://prisoner-search.prison.service.justice.gov.uk/prisoner/${nomsNumber}"}`,
+          Timestamp: '2024-07-25T06:57:39.938Z',
+          SignatureVersion: '1',
+          Signature: 'fakesig',
+          SigningCertURL: 'https://some.pem',
+          UnsubscribeURL: 'https://fake.url',
+          MessageAttributes: {
+            traceparent: { Type: 'String', Value: 'a-guid' },
+            eventType: { Type: 'String', Value: 'prisoner-offender-search.prisoner.released' },
+          },
+        }),
+      }
+    }
+
+    it('should delete pending categorisations', async () => {
+      const event = createPrisonerReleasedMessage(offenderId)
+
+      await service.eventQueueConsumer.handleMessage(event)
+
+      expect(formService.deletePendingCategorisations).toHaveBeenCalledTimes(1)
+      expect(formService.deletePendingCategorisations.mock.calls[0][0]).toEqual(offenderId)
+      expect(formService.deletePendingCategorisations.mock.calls[0][1]).toEqual(mockTransactionalClient)
+    })
+
+    it('should exit early if a nomsNumber is unavailable', async () => {
+      const event = createPrisonerReleasedMessage('')
+
+      await service.eventQueueConsumer.handleMessage(event)
+
+      expect(formService.deletePendingCategorisations).not.toHaveBeenCalled()
+    })
   })
 })

--- a/test/services/sqsService.test.js
+++ b/test/services/sqsService.test.js
@@ -171,5 +171,16 @@ describe('eventQueueConsumer', () => {
 
       expect(formService.deletePendingCategorisations).not.toHaveBeenCalled()
     })
+
+    // -- spacer
+    ;[null, false, 'OTHER_REASON', '', 'reason'].forEach(invalidReason => {
+      it(`should only delete when the reason is "RELEASED", given: "${invalidReason}"`, async () => {
+        const event = createPrisonerReleasedMessage(offenderId, invalidReason)
+
+        await service.eventQueueConsumer.handleMessage(event)
+
+        expect(formService.deletePendingCategorisations).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/test/utils/eventUtils.test.js
+++ b/test/utils/eventUtils.test.js
@@ -1,0 +1,9 @@
+const { events } = require('../../server/utils/eventUtils')
+
+describe('eventUtils', () => {
+  it('it exposes the EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED event identifier', () => {
+    expect(events.EVENT_DOMAIN_PRISONER_OFFENDER_SEARCH_PRISONER_RELEASED).toEqual(
+      'prisoner-offender-search.prisoner.released'
+    )
+  })
+})


### PR DESCRIPTION
Listen for Offender Release events. Delete any pending (not APPROVED or CANCELLED) cats, recats, and lite cats for the offender.

This is currently behind an inactive feature flag, and for the moment will only log what we would have deleted. 