### PR TITLE
Adding typescript support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           paths:
             - node_modules
             - assets/stylesheets
+            - dist
   test:
     executor: builder
     steps:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,59 @@
     "jest": true
   },
 
+  "settings": {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"]
+    },
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      },
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx", ".json"]
+      }
+    }
+  },
+
+  "overrides": [
+    {
+      "plugins": ["@typescript-eslint"],
+      "parser": "@typescript-eslint/parser",
+      "files": ["**/*.ts"],
+      "excludedFiles": ["*.js", "./integration_tests/**"],
+      "extends": [
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:prettier/recommended"
+      ],
+      "rules": {
+        "@typescript-eslint/no-shadow": ["error", { "ignoreTypeValueShadow": true }],
+        "@typescript-eslint/no-use-before-define": 0,
+        "class-methods-use-this": 0,
+        "no-useless-constructor": 0,
+        "@typescript-eslint/no-unused-vars": [
+          1,
+          {
+            "argsIgnorePattern": "res|next|^err|_",
+            "ignoreRestSiblings": true
+          }
+        ],
+        "@typescript-eslint/semi": 0,
+        "import/no-unresolved": "error",
+        "prettier/prettier": [
+          "error",
+          {
+            "trailingComma": "es5",
+            "singleQuote": true,
+            "printWidth": 120,
+            "semi": false,
+            "arrowParens": "avoid"
+          }
+        ]
+      }
+    }
+  ],
+
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
@@ -21,6 +74,17 @@
     ],
     "no-use-before-define": 0,
     "semi": 0,
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "mjs": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     "comma-dangle": [
       "error",
       {

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ integration_tests/screenshots/*
 volume/cache
 test_results/*
 lib/
+dist
+test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,86 @@
-FROM node:20.12-bookworm-slim
-LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+# Stage: base image
 ARG BUILD_NUMBER
 ARG GIT_REF
 
-RUN apt-get update && \
-  apt-get upgrade -y && \
-  apt-get install -y curl && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*
+FROM node:20.12-bookworm-slim as base
+
+LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
 
 RUN addgroup --gid 2000 --system appgroup && \
-  adduser --uid 2000 --system appuser --gid 2000
+    adduser --uid 2000 --system appuser --gid 2000
 
-# Create app directory
-RUN mkdir -p /app
 WORKDIR /app
-ADD . .
 
-# Install AWS RDS Root cert
-RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem > /app/root.cert
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl
+
+# Stage: build assets
+FROM base as build
+ARG BUILD_NUMBER
+ARG GIT_REF
+
+RUN apt-get install -y make python3 wget gnupg gnupg1 gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit
+
+COPY . .
+RUN npm run build
 
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 ENV GIT_REF ${GIT_REF:-dummy}
-RUN npm ci --no-audit && \
-  npm run build && \
-  export BUILD_NUMBER=${BUILD_NUMBER} && \
-  export GIT_REF=${GIT_REF} && \
-  npm run record-build-info
+RUN export BUILD_NUMBER=${BUILD_NUMBER} && \
+    export GIT_REF=${GIT_REF} && \
+    npm run record-build-info
 
 RUN npm prune --no-audit --production
-RUN rm -rf /root/.cache
 
-ENV PORT=3000
-ENV NODE_ENV='production'
+# Stage: copy production assets and dependencies
+FROM base
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+ENV GIT_REF ${GIT_REF:-dummy}
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install AWS RDS Root cert
+RUN mkdir -p /home/appuser/.postgresql \
+    && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+    > /app/root.cert
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/package.json \
+    /app/package-lock.json \
+    /app/log.js \
+    ./
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/build-info.json ./dist/build-info.json
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/assets ./assets
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/dist ./dist
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/node_modules ./node_modules
+
+COPY --from=build --chown=appuser:appgroup \
+    /app/migrations ./migrations
+
 EXPOSE 3000
-
-RUN chown -R appuser:appgroup /app
-
+ENV NODE_ENV='production'
 USER 2000
 
 CMD [ "npm", "start" ]

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,3 +1,7 @@
+/* eslint-disable global-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable import/extensions */
+/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import mockApis from './integration_tests/mockApis'

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "querystring": "^0.2.1",
         "ramda": "^0.28.0",
         "redis": "^3.1.2",
-        "sass": "^1.77.8",
         "sqs-consumer": "^5.8.0",
         "superagent": "^9.0.1",
         "uuid": "^8.3.2"
@@ -59,6 +58,8 @@
         "@types/connect-flash": "0.0.40",
         "@types/cookie-session": "^2.0.49",
         "@types/csurf": "^1.11.5",
+        "@types/dotenv": "^8.2.0",
+        "@types/express": "^4.17.21",
         "@types/express-session": "^1.18.0",
         "@types/http-errors": "^2.0.4",
         "@types/jest": "^29.5.12",
@@ -76,7 +77,7 @@
         "audit-ci": "^6.6.1",
         "concurrently": "^8.2.2",
         "cookie-session": "^2.0.0",
-        "cypress": "^13.14.0",
+        "cypress": "^13.14.1",
         "cypress-multi-reporters": "^1.6.4",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -97,6 +98,7 @@
         "nodemon": "^3.1.4",
         "prettier": "^3.3.3",
         "prettier-plugin-jinja-template": "^1.5.0",
+        "sass": "^1.77.8",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.5.4"
@@ -1866,6 +1868,16 @@
         "@types/express-serve-static-core": "*"
       }
     },
+    "node_modules/@types/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -2553,6 +2565,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3082,6 +3095,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3163,6 +3177,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3429,6 +3444,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -3455,6 +3471,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4036,9 +4053,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.0.tgz",
-      "integrity": "sha512-r0+nhd033x883YL6068futewUsl02Q7rWiinyAAIBDW/OOTn+UMILWgNuCiY3vtJjd53efOqq5R9dctQk/rKiw==",
+      "version": "13.14.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
+      "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5531,6 +5548,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5704,6 +5722,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -6254,7 +6273,8 @@
     "node_modules/immutable": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -6425,6 +6445,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6516,6 +6537,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6556,6 +6578,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6595,6 +6618,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9086,6 +9110,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9697,6 +9722,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -10145,6 +10171,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -10480,6 +10507,7 @@
       "version": "1.77.8",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
       "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -10730,6 +10758,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11154,6 +11183,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "offender-categorisation",
   "version": "0.0.1",
   "scripts": {
-    "start": "npm run build && node server.js",
-    "start:dev": "npm run build && DEBUG=gov-starter-server* nodemon --inspect server.js | bunyan -o short",
-    "start:debug": "node --inspect server.js",
-    "compile-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice ./assets/sass/application.sass:./assets/stylesheets/application.css --style compressed",
+    "start": "node dist/server.js | bunyan -o short",
+    "start:dev": "npm run build && DEBUG=gov-starter-server* TOKEN_VERIFICATION_API_ENABLED=false && concurrently -k -p \"[{name}]\" -n \"Views,TypeScript,Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-views\" \"npm run watch-ts\" \"npm run watch-node\" \"npm run watch-sass\"",
+    "start:debug": "node --inspect dist/server.js",
+    "compile-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend/dist  --load-path=node_modules/@ministryofjustice ./assets/sass/application.sass:./assets/stylesheets/application.css --style compressed",
+    "watch-node": "nodemon --watch dist/ dist/server.js | bunyan -o short",
     "watch-sass": "npm run compile-sass -- --watch",
-    "build": "npm run compile-sass",
+    "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
+    "watch-ts": "tsc -w",
+    "build": "npm run compile-sass && tsc && npm run copy-views",
     "clean": "rm -rf assets/stylesheets/* .port.tmp *.log dist build/* uploads/* test-results.xml",
     "lint": "eslint . --cache --max-warnings 0",
     "test": "jest",
@@ -20,8 +23,46 @@
     "int-test": "export $(cat feature.env) && cypress run --config video=false",
     "int-test-ui": "export $(cat feature.env) && cypress open",
     "watch-node-feature": "export $(cat feature.env) && npm run start:dev",
-    "start-feature": "export $(cat feature.env) && npm run build && node $NODE_DEBUG_OPTION server.js | bunyan -o short",
-    "start-feature:dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-node-feature\" \"npm run watch-sass\""
+    "start-feature": "export $(cat feature.env) && npm run build && node $NODE_DEBUG_OPTION dist/server.js | bunyan -o short",
+    "start-feature:dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-node-feature\" \"npm run watch-sass\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "collectCoverageFrom": [
+      "server/**/*.{ts,js,jsx,mjs}",
+      "jobs/**/*.{ts,js,jsx,mjs}"
+    ],
+    "testMatch": [
+      "<rootDir>/test/**/*.(spec|test).{ts,js,jsx,mjs}",
+      "<rootDir>/server/**/*.(spec|test).{ts,js,jsx,mjs}"
+    ],
+    "testEnvironment": "node",
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "outputDirectory": "test-results/jest/"
+        }
+      ],
+      [
+        "./node_modules/jest-html-reporter",
+        {
+          "outputPath": "test-results/unit-test-reports.html"
+        }
+      ]
+    ],
+    "moduleFileExtensions": [
+      "web.js",
+      "js",
+      "json",
+      "ts",
+      "web.jsx",
+      "jsx",
+      "node",
+      "mjs"
+    ]
   },
   "engines": {
     "node": ">= 20.11.0",
@@ -80,6 +121,7 @@
     "sass": "^1.77.8",
     "sqs-consumer": "^5.8.0",
     "superagent": "^9.0.1",
+    "typescript": "^5.5.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -89,6 +131,8 @@
     "@types/connect-flash": "0.0.40",
     "@types/cookie-session": "^2.0.49",
     "@types/csurf": "^1.11.5",
+    "@types/dotenv": "^8.2.0",
+    "@types/express": "^4.17.21",
     "@types/express-session": "^1.18.0",
     "@types/http-errors": "^2.0.4",
     "@types/jest": "^29.5.12",
@@ -106,7 +150,7 @@
     "audit-ci": "^6.6.1",
     "concurrently": "^8.2.2",
     "cookie-session": "^2.0.0",
-    "cypress": "^13.14.0",
+    "cypress": "^13.14.1",
     "cypress-multi-reporters": "^1.6.4",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -128,8 +172,7 @@
     "prettier": "^3.3.3",
     "prettier-plugin-jinja-template": "^1.5.0",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.5",
-    "typescript": "^5.5.4"
+    "ts-jest": "^29.2.5"
   },
   "snyk": true
 }

--- a/package.json
+++ b/package.json
@@ -118,10 +118,8 @@
     "querystring": "^0.2.1",
     "ramda": "^0.28.0",
     "redis": "^3.1.2",
-    "sass": "^1.77.8",
     "sqs-consumer": "^5.8.0",
     "superagent": "^9.0.1",
-    "typescript": "^5.5.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -171,8 +169,10 @@
     "nodemon": "^3.1.4",
     "prettier": "^3.3.3",
     "prettier-plugin-jinja-template": "^1.5.0",
+    "sass": "^1.77.8",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.5"
+    "ts-jest": "^29.2.5",
+    "typescript": "^5.5.4"
   },
   "snyk": true
 }

--- a/server/app.js
+++ b/server/app.js
@@ -118,19 +118,20 @@ module.exports = function createApp({
   const cacheControl = { maxAge: config.staticResourceCacheDuration * 1000 }
 
   ;[
-    '../assets',
-    '../assets/stylesheets',
-    '../node_modules/govuk-frontend/dist/govuk/assets',
-    '../node_modules/govuk-frontend/dist',
-    '../node_modules/@ministryofjustice/frontend/moj/assets',
-    '../node_modules/@ministryofjustice/frontend',
+    '/assets',
+    '/assets/stylesheets',
+    '/assets/js',
+    '/node_modules/govuk-frontend/dist/govuk/assets',
+    '/node_modules/govuk-frontend/dist',
+    '/node_modules/@ministryofjustice/frontend/moj/assets',
+    '/node_modules/@ministryofjustice/frontend',
   ].forEach(dir => {
-    app.use('/assets', express.static(path.join(__dirname, dir), cacheControl))
+    app.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })
-  ;['../node_modules/govuk_frontend_toolkit/images'].forEach(dir => {
-    app.use('/assets/images/icons', express.static(path.join(__dirname, dir), cacheControl))
+  ;['/node_modules/govuk_frontend_toolkit/images'].forEach(dir => {
+    app.use('/assets/images/icons', express.static(path.join(process.cwd(), dir), cacheControl))
   })
-  app.use('/favicon.ico', express.static(path.join(__dirname, '../assets/images/favicon.ico'), cacheControl))
+  app.use('/favicon.ico', express.static(path.join(process.cwd(), '/assets/images/favicon.ico'), cacheControl))
 
   const health = healthFactory(
     config.apis.oauth2.url,
@@ -153,7 +154,7 @@ module.exports = function createApp({
   })
 
   // GovUK Template Configuration
-  app.locals.asset_path = '/assets/'
+  app.locals.asset_path = '/dist/assets/'
 
   function addTemplateVariables(req, res, next) {
     res.locals.user = req.user
@@ -316,7 +317,7 @@ module.exports = function createApp({
 
   app.use(
     '/assets/moj-frontend/moj/all.js',
-    express.static(path.join(process.cwd(), '../node_modules/@ministryofjustice/frontend/moj/all.js'), cacheControl)
+    express.static(path.join(process.cwd(), '/node_modules/@ministryofjustice/frontend/moj/all.js'), cacheControl)
   )
 
   app.use(errorHandler(production))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "target": "es2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "skipLibCheck": true,
+    "noEmit": false,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "typeRoots": [
+      "./server/@types",
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "assets/**/*.js",
+    "integration-tests",
+    "integration_tests",
+    "dist",
+    "coverage",
+    "**/__mocks__/*",
+    "./cypress.config.ts",
+    "cypress",
+    "**/*.cy.tsx"
+  ],
+  "include": [
+    "**/*.js",
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds typescript support into offender-categorisation and therefore also moves to serving the compiled assets from the dist folder.