### PR TITLE
[SI-1260] Timeout /health endpoint db check after 30 seconds

### DIFF
--- a/server/data/healthCheck.js
+++ b/server/data/healthCheck.js
@@ -6,7 +6,19 @@ const db = require('./dataAccess/db')
 const getSanitisedError = require('../sanitisedError')
 
 function dbCheck() {
-  return db.query('SELECT 1 AS ok')
+  const MAX_WAIT = 30 * 1000 // 30 seconds
+  const timeout = new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error('Database Connection test timed out'))
+    }, MAX_WAIT)
+  })
+  return Promise.race([db.query('SELECT 1 AS ok'), timeout])
+    .then(success => {
+      return true // The connection is working
+    })
+    .catch(e => {
+      throw e
+    })
 }
 
 const agentOptions = {

--- a/server/data/healthCheck.js
+++ b/server/data/healthCheck.js
@@ -13,7 +13,7 @@ function dbCheck() {
     }, MAX_WAIT)
   })
   return Promise.race([db.query('SELECT 1 AS ok'), timeout])
-    .then(success => {
+    .then(() => {
       return true // The connection is working
     })
     .catch(e => {


### PR DESCRIPTION
Implementation stolen from https://github.com/brianc/node-postgres/issues/3124#issuecomment-1958782624

Adds tests to check that.

Can also test locally by changing the query (https://github.com/ministryofjustice/offender-categorisation/compare/feature/SI-1260-timeout-health-endpoint-after-30-seconds-db-call?expand=1#diff-1c1a8c93ae110219d1bda8b4db7ba1be4fca1ee44905b31d8258af3a1b78afe4R15) to:

`SELECT pg_sleep(3000)`

and set `MAX_WAIT` (https://github.com/ministryofjustice/offender-categorisation/compare/feature/SI-1260-timeout-health-endpoint-after-30-seconds-db-call?expand=1#diff-1c1a8c93ae110219d1bda8b4db7ba1be4fca1ee44905b31d8258af3a1b78afe4R9) to 1000 or similar. 