### PR TITLE
[SI-1263] Adds 'jobs' dir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,9 @@ COPY --from=build --chown=appuser:appgroup \
 COPY --from=build --chown=appuser:appgroup \
     /app/migrations ./migrations
 
+COPY --from=build --chown=appuser:appgroup \
+    /app/jobs ./jobs
+
 EXPOSE 3000
 ENV NODE_ENV='production'
 USER 2000


### PR DESCRIPTION
Hopefully fixes DLQ issue

```
kubectl logs -n offender-categorisation-prod dead-letter-28817651-swtsd  --follow
node:internal/modules/cjs/loader:1146
  throw err;
  ^

Error: Cannot find module '/app/jobs/dead-letter/clearDeadLetterQueuesWithExit'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1143:15)
    at Module._load (node:internal/modules/cjs/loader:984:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.12.2
```

when i went on a pod

```
➜  Development kubectl -n offender-categorisation-prod exec -it offender-categorisation-568f7d7dff-5pvqb -- /bin/bash
appuser@offender-categorisation-568f7d7dff-5pvqb:/app$ cd /app/
appuser@offender-categorisation-568f7d7dff-5pvqb:/app$ ls
assets	dist  log.js  migrations  node_modules	package-lock.json  package.json  root.cert
```

jobs dir is not there