### PR TITLE
Added in logging and slight refactor to improve performance

### DIFF
--- a/server/data/risksAndNeeds/risksAndNeedsApi.ts
+++ b/server/data/risksAndNeeds/risksAndNeedsApi.ts
@@ -38,6 +38,7 @@ const builder: RisksAndNeedsApiClientBuilder = user => {
     async getRisksSummary(crn): Promise<RiskSummaryDto> {
       const cached = cache.get(crn)
       if (cached) {
+        logger.info('Risks and needs API: returned from cache')
         return cached
       }
 

--- a/server/services/recategorisation/filter/recategorisationFilter.ts
+++ b/server/services/recategorisation/filter/recategorisationFilter.ts
@@ -244,7 +244,7 @@ export const filterListOfPrisoners = async (
 
   let offenderNumbersWithAdjudications = []
   if (allFilters.includes(NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS)) {
-    const adjudicationsData = await loadAdjudicationsData(prisoners, nomisClient, agencyId)
+    const adjudicationsData = await loadAdjudicationsData(filteredPrisoners, nomisClient, agencyId)
     offenderNumbersWithAdjudications = adjudicationsData.map(adjudicationsDatum => adjudicationsDatum.offenderNo)
     filteredPrisoners = filteredPrisoners.filter(prisoner => {
       return !offenderNumbersWithAdjudications.includes(prisoner.offenderNo)
@@ -253,7 +253,7 @@ export const filterListOfPrisoners = async (
   let offenderNumbersWithLowRoshScore = []
   if (allFilters.includes(LOW_ROSH)) {
     offenderNumbersWithLowRoshScore = await getOffenderNumbersWithLowRoshScore(
-      prisoners,
+      filteredPrisoners,
       risksAndNeedsClient,
       probationOffenderSearchClient
     )

--- a/server/services/recategorisation/filter/recategorisationFilter.ts
+++ b/server/services/recategorisation/filter/recategorisationFilter.ts
@@ -21,7 +21,7 @@ import { PrisonerAllocationDto } from '../../../data/allocationManager/prisonerA
 import { ProbationOffenderSearchApiClient } from '../../../data/probationOffenderSearch/probationOffenderSearchApiClient'
 import { RisksAndNeedsApiClient } from '../../../data/risksAndNeeds/risksAndNeedsApi'
 import { OverallRiskLevel } from '../../../data/risksAndNeeds/riskSummary.dto'
-import logger from "../../../../log";
+import logger from '../../../../log'
 
 export const SUITABILIGY_FOR_OPEN_CONDITIONS = 'suitabilityForOpenConditions'
 export const DUE_DATE = 'dueDate'
@@ -116,9 +116,9 @@ const getOffenderNumbersWithLowRoshScore = async (
 ) => {
   const prisonerNumbersWithLowRoshScore = []
   const prisonerNumbers = prisoners.map(prisoner => prisoner.offenderNo)
-  let timeNow = new Date()
+  let startTime = Date.now()
   const probationOffenderSearchOffenders = await probationOffenderSearchClient.matchPrisoners(prisonerNumbers)
-  logger.info(`CAT prioritisation filter investigation: fetching crns took ${new Date() - timeNow}ms`)
+  logger.info(`CAT prioritisation filter investigation: fetching crns took ${Date.now() - startTime}ms`)
   if (typeof probationOffenderSearchOffenders === 'undefined') {
     return []
   }
@@ -128,7 +128,7 @@ const getOffenderNumbersWithLowRoshScore = async (
       probationOffenderSearchOffender.otherIds.nomsNumber,
     ])
   )
-  timeNow = new Date()
+  startTime = Date.now()
   let crnsWithNoRoshLevel = 0
   const BATCH_SIZE = 50
   for (let range = 0; range < Object.keys(crnsToOffenderNumbers).length; range += BATCH_SIZE) {
@@ -147,7 +147,7 @@ const getOffenderNumbersWithLowRoshScore = async (
       })
     )
   }
-  logger.info(`CAT prioritisation filter investigation: fetching RoSH took ${new Date() - timeNow}ms`)
+  logger.info(`CAT prioritisation filter investigation: fetching RoSH took ${Date.now() - startTime}ms`)
   logger.info(`CAT prioritisation filter investigation: ${crnsWithNoRoshLevel} crns without RoSH level`)
   return prisonerNumbersWithLowRoshScore
 }
@@ -169,8 +169,8 @@ export const filterListOfPrisoners = async (
     return prisoners
   }
   // in order to improve load time we should apply any filters which don't require further data to be loaded first
-  const allFiltersWhichDoNotRequireFurtherDataToBeLoaded = allFilters.filter(filter =>
-    [NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS, LOW_ROSH].includes(filter)
+  const allFiltersWhichDoNotRequireFurtherDataToBeLoaded = allFilters.filter(
+    filter => ![NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS, LOW_ROSH].includes(filter)
   )
   let filteredPrisoners = prisoners.filter(prisoner => {
     const currentPrisonerSearchData = prisonerSearchData.get(prisoner.bookingId)
@@ -236,7 +236,7 @@ export const filterListOfPrisoners = async (
           }
           break
         default:
-          throw new Error(`Invalid filter type: ${allFilters[i]}`)
+          throw new Error(`Invalid filter type: ${allFiltersWhichDoNotRequireFurtherDataToBeLoaded[i]}`)
       }
     }
     return true

--- a/server/services/recategorisation/filter/recategorisationFilter.ts
+++ b/server/services/recategorisation/filter/recategorisationFilter.ts
@@ -21,6 +21,7 @@ import { PrisonerAllocationDto } from '../../../data/allocationManager/prisonerA
 import { ProbationOffenderSearchApiClient } from '../../../data/probationOffenderSearch/probationOffenderSearchApiClient'
 import { RisksAndNeedsApiClient } from '../../../data/risksAndNeeds/risksAndNeedsApi'
 import { OverallRiskLevel } from '../../../data/risksAndNeeds/riskSummary.dto'
+import logger from "../../../../log";
 
 export const SUITABILIGY_FOR_OPEN_CONDITIONS = 'suitabilityForOpenConditions'
 export const DUE_DATE = 'dueDate'
@@ -115,7 +116,9 @@ const getOffenderNumbersWithLowRoshScore = async (
 ) => {
   const prisonerNumbersWithLowRoshScore = []
   const prisonerNumbers = prisoners.map(prisoner => prisoner.offenderNo)
+  let timeNow = new Date()
   const probationOffenderSearchOffenders = await probationOffenderSearchClient.matchPrisoners(prisonerNumbers)
+  logger.info(`CAT prioritisation filter investigation: fetching crns took ${new Date() - timeNow}ms`)
   if (typeof probationOffenderSearchOffenders === 'undefined') {
     return []
   }
@@ -125,19 +128,27 @@ const getOffenderNumbersWithLowRoshScore = async (
       probationOffenderSearchOffender.otherIds.nomsNumber,
     ])
   )
-  const BATCH_SIZE = 20
+  timeNow = new Date()
+  let crnsWithNoRoshLevel = 0
+  const BATCH_SIZE = 50
   for (let range = 0; range < Object.keys(crnsToOffenderNumbers).length; range += BATCH_SIZE) {
     const crnBatch = Object.keys(crnsToOffenderNumbers).slice(range, range + BATCH_SIZE)
     // eslint-disable-next-line no-await-in-loop
     await Promise.all(
+      // eslint-disable-next-line no-loop-func
       crnBatch.map(async crn => {
         const risksSummary = await risksAndNeedsClient.getRisksSummary(crn)
+        if (typeof risksSummary.overallRiskLevel === 'undefined') {
+          crnsWithNoRoshLevel += 1
+        }
         if (risksSummary.overallRiskLevel === OverallRiskLevel.low) {
           prisonerNumbersWithLowRoshScore.push(crnsToOffenderNumbers[crn])
         }
       })
     )
   }
+  logger.info(`CAT prioritisation filter investigation: fetching RoSH took ${new Date() - timeNow}ms`)
+  logger.info(`CAT prioritisation filter investigation: ${crnsWithNoRoshLevel} crns without RoSH level`)
   return prisonerNumbersWithLowRoshScore
 }
 
@@ -157,20 +168,11 @@ export const filterListOfPrisoners = async (
   if (allFilters.length <= 0) {
     return prisoners
   }
-  let offenderNumbersWithAdjudications = []
-  if (allFilters.includes(NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS)) {
-    const adjudicationsData = await loadAdjudicationsData(prisoners, nomisClient, agencyId)
-    offenderNumbersWithAdjudications = adjudicationsData.map(adjudicationsDatum => adjudicationsDatum.offenderNo)
-  }
-  let offenderNumbersWithLowRoshScore = []
-  if (allFilters.includes(LOW_ROSH)) {
-    offenderNumbersWithLowRoshScore = await getOffenderNumbersWithLowRoshScore(
-      prisoners,
-      risksAndNeedsClient,
-      probationOffenderSearchClient
-    )
-  }
-  return prisoners.filter(prisoner => {
+  // in order to improve load time we should apply any filters which don't require further data to be loaded first
+  const allFiltersWhichDoNotRequireFurtherDataToBeLoaded = allFilters.filter(filter =>
+    [NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS, LOW_ROSH].includes(filter)
+  )
+  let filteredPrisoners = prisoners.filter(prisoner => {
     const currentPrisonerSearchData = prisonerSearchData.get(prisoner.bookingId)
     const activeNonExpiredAlertCodes =
       (currentPrisonerSearchData &&
@@ -179,8 +181,8 @@ export const filterListOfPrisoners = async (
           .map(alert => alert.alertCode)) ||
       []
     const incentiveLevelCode = currentPrisonerSearchData?.currentIncentive?.level.code
-    for (let i = 0; i < allFilters.length; i += 1) {
-      switch (allFilters[i]) {
+    for (let i = 0; i < allFiltersWhichDoNotRequireFurtherDataToBeLoaded.length; i += 1) {
+      switch (allFiltersWhichDoNotRequireFurtherDataToBeLoaded[i]) {
         case LOW_RISK_OF_ESCAPE:
           if (
             activeNonExpiredAlertCodes.includes(ESCAPE_RISK_ALERT_CODE) ||
@@ -200,11 +202,6 @@ export const filterListOfPrisoners = async (
             activeNonExpiredAlertCodes.includes(RESTRICTED_ROTL_ALERT_CODE) ||
             activeNonExpiredAlertCodes.includes(ROTL_SUSPENSION_ALERT_CODE)
           ) {
-            return false
-          }
-          break
-        case NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS:
-          if (offenderNumbersWithAdjudications.includes(prisoner.offenderNo)) {
             return false
           }
           break
@@ -228,11 +225,6 @@ export const filterListOfPrisoners = async (
             return false
           }
           break
-        case LOW_ROSH:
-          if (!offenderNumbersWithLowRoshScore.includes(prisoner.offenderNo)) {
-            return false
-          }
-          break
         case OVERDUE:
           if (!isReviewOverdue(prisoner.nextReviewDate)) {
             return false
@@ -249,4 +241,26 @@ export const filterListOfPrisoners = async (
     }
     return true
   })
+
+  let offenderNumbersWithAdjudications = []
+  if (allFilters.includes(NO_ADJUDICATIONS_IN_THE_LAST_3_MONTHS)) {
+    const adjudicationsData = await loadAdjudicationsData(prisoners, nomisClient, agencyId)
+    offenderNumbersWithAdjudications = adjudicationsData.map(adjudicationsDatum => adjudicationsDatum.offenderNo)
+    filteredPrisoners = filteredPrisoners.filter(prisoner => {
+      return !offenderNumbersWithAdjudications.includes(prisoner.offenderNo)
+    })
+  }
+  let offenderNumbersWithLowRoshScore = []
+  if (allFilters.includes(LOW_ROSH)) {
+    offenderNumbersWithLowRoshScore = await getOffenderNumbersWithLowRoshScore(
+      prisoners,
+      risksAndNeedsClient,
+      probationOffenderSearchClient
+    )
+    filteredPrisoners = filteredPrisoners.filter(prisoner => {
+      return offenderNumbersWithLowRoshScore.includes(prisoner.offenderNo)
+    })
+  }
+
+  return filteredPrisoners
 }


### PR DESCRIPTION
Improvements for performance:
- ordering the filters so that it will apply all filters which don't require more data to be loaded first, and using the filtered list of prisoners to load data for the further filters.
- increased the batch size of the rosh data so more will be done in parallel.

logging added:
- to see if it's using the cache for RoSH correctly
- to see how long it takes to complete the fetching of crns and full fetching of RoSH data
- to see how many crns have no RoSH level