### PR TITLE
added in some smaller improvements / changes to logging for the prioritisation filter

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -323,6 +323,9 @@ $sideFilterWidth: 350px
 .recategorisation-reason-for-review-column
   min-width: 85px
 
+.text-break-word
+  word-break: break-word
+
 @media only screen and (max-width: $xlBreakpoint)
   .recategorisation-scrollable-pane
     overflow-x: scroll
@@ -335,4 +338,7 @@ $sideFilterWidth: 350px
 
   .recategorisation-reason-for-review-column
     min-width: auto
+
+  .text-break-word
+    word-break: normal
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ generic-service:
     ALLOCATION_MANAGER_ENDPOINT_URL: https://preprod.moic.service.justice.gov.uk/
     PRISONER_SEARCH_ENDPOINT_URL: https://prisoner-search-preprod.prison.service.justice.gov.uk/
     RISKS_AND_NEEDS_ENDPOINT_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk/
+    RISKS_AND_NEEDS_ENDPOINT_URL_RESPONSE: 45000
     PROBATION_OFFENDER_SEARCH_ENDPOINT_URL: https://probation-offender-search-preprod.hmpps.service.justice.gov.uk/
     DPS_URL: https://digital-preprod.prison.service.justice.gov.uk/
     SUPPORT_URL: https://support-preprod.hmpps.service.justice.gov.uk/

--- a/server/data/risksAndNeeds/risksAndNeedsApi.ts
+++ b/server/data/risksAndNeeds/risksAndNeedsApi.ts
@@ -16,7 +16,7 @@ export interface RisksAndNeedsApiClient {
 
 // there are about 80000 prisoner altogether but they wont all be due for categorisation
 // 4 hour TTL is fine for slowly changing POM data but should give good hit ratio
-const cache = new LRU({ max: 30000, maxAge: 1000 * 60 * 60 * 4 })
+const cache = new LRU({ max: 50000, maxAge: 1000 * 60 * 60 * 24 })
 
 const timeoutSpec = {
   response: config.apis.risksAndNeeds.timeout.response,
@@ -38,7 +38,6 @@ const builder: RisksAndNeedsApiClientBuilder = user => {
     async getRisksSummary(crn): Promise<RiskSummaryDto> {
       const cached = cache.get(crn)
       if (cached) {
-        logger.info('Risks and needs API: returned from cache')
         return cached
       }
 

--- a/server/views/pages/recategoriserHome.html
+++ b/server/views/pages/recategoriserHome.html
@@ -181,7 +181,7 @@
                 {{ row.nextReviewDateDisplay }}
               {% endif %}
             </td>
-            <td class="govuk-table__cell"><a class="govuk-!-text-break-word" target="_blank" href="{{ row.offenderNo | offenderLink }}">{{ row.displayName }}</a>
+            <td class="govuk-table__cell"><a class="text-break-word" target="_blank" href="{{ row.offenderNo | offenderLink }}">{{ row.displayName }}</a>
               {% if row.securityReferred %}
                 {{ govukDetails({
                 summaryText: 'Security referred',
@@ -201,7 +201,7 @@
                 {{ row.displayStatus }}
               {% endif %}
             </td>
-            <td class="govuk-table__cell govuk-!-text-break-word">{{ row.pom }}</td>
+            <td class="govuk-table__cell text-break-word">{{ row.pom }}</td>
             <td class="govuk-table__cell govuk-!-margin-top-2 govuk-!-margin-bottom-8">
               {% set basicClasses = "tableButton govuk-!-padding-left-3 govuk-!-padding-right-3" %}
               {% set href = ("/form/awaitingApprovalView/" + row.bookingId) if row.displayStatus == 'Awaiting approval'


### PR DESCRIPTION
- Word break to stop table overflowing container on larger screen sizes
- increased timeout of the assess risks and needs API on preprod
- increased cache
- reduced the batch size of requests to RoSH (because a lot were timing out)
- Chris's suggestion to call adjudications and RoSH endpoints in parallel to save a little more time blocking.