### PR TITLE
Si 941 check agency id of prisoner matches the current active caseload ID middleware

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -95,6 +95,6 @@
         "functions": "never"
       }
     ],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": ["**/*.test.js", "**/*.test.ts", "/test/**/*"] }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,6 +94,7 @@
         "exports": "never",
         "functions": "never"
       }
-    ]
+    ],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
   }
 }

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
@@ -947,7 +947,7 @@ class Elite2Api extends WireMockRule {
       .willReturn(aResponse()
         .withBody(JsonOutput.toJson([bookingId  : bookingId,
                                      offenderNo : offenderNo,
-                                     agencyId   : 'LEI',
+                                     agencyId   : 'PFI',
                                      firstName  : 'ANT',
                                      lastName   : 'HILLMOB',
                                      dateOfBirth: '1970-02-17',]))

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/mockapis/Elite2Api.groovy
@@ -942,12 +942,12 @@ class Elite2Api extends WireMockRule {
   }
 
 
-  def stubGetBasicOffenderDetails(int bookingId, offenderNo = 'B2345YZ') {
+  def stubGetBasicOffenderDetails(int bookingId, offenderNo = 'B2345YZ', String caseloadId = 'LEI') {
     this.stubFor(get("/api/bookings/$bookingId?basicInfo=true")
       .willReturn(aResponse()
         .withBody(JsonOutput.toJson([bookingId  : bookingId,
                                      offenderNo : offenderNo,
-                                     agencyId   : 'PFI',
+                                     agencyId   : caseloadId,
                                      firstName  : 'ANT',
                                      lastName   : 'HILLMOB',
                                      dateOfBirth: '1970-02-17',]))

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.cattool.pages.recat.RecategoriserHomePage
 import uk.gov.justice.digital.hmpps.cattool.specs.AbstractSpecification
 
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.FEMALE_RECAT_USER
 
@@ -69,7 +70,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Mini Higher Security Review page'
     fixture.gotoTasklistRecatForCatI(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(21)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -227,7 +228,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(21)
+    elite2Api.stubGetBasicOffenderDetails(21, '', 'PFI')
     decisionButton.click()
 
     when: 'I dont select anything'
@@ -271,7 +272,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(21)
+    elite2Api.stubGetBasicOffenderDetails(21, '', 'PFI')
     decisionButton.click()
 
     when: 'Open option is submitted'

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
@@ -20,7 +20,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Decision page'
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -56,7 +56,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the decision page'
     fixture.gotoTasklistRecatForCatIIndeterminate(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
 
     then: 'The page is displayed without open condition options'
@@ -69,7 +69,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Mini Higher Security Review page'
     fixture.gotoTasklistRecatForCatI(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(21)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -126,7 +126,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Decision page'
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -202,8 +202,8 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I submit the page with empty details'
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
-    elite2Api.stubGetBasicOffenderDetails(700)
     to DecisionPage, '12'
 
     at DecisionPage
@@ -227,7 +227,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(21)
     decisionButton.click()
 
     when: 'I dont select anything'
@@ -271,7 +271,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(21)
     decisionButton.click()
 
     when: 'Open option is submitted'

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
@@ -70,7 +70,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Mini Higher Security Review page'
     fixture.gotoTasklistRecatForCatI(false)
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(12)
+    elite2Api.stubGetBasicOffenderDetails(21)
     decisionButton.click()
 
     then: 'The page is displayed'

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
@@ -20,6 +20,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Decision page'
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -55,6 +56,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the decision page'
     fixture.gotoTasklistRecatForCatIIndeterminate(false)
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     then: 'The page is displayed without open condition options'
@@ -67,6 +69,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Mini Higher Security Review page'
     fixture.gotoTasklistRecatForCatI(false)
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -123,6 +126,7 @@ class DecisionSpecification extends AbstractSpecification {
     when: 'I go to the Decision page'
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     then: 'The page is displayed'
@@ -199,6 +203,7 @@ class DecisionSpecification extends AbstractSpecification {
     fixture.gotoTasklistRecat(false)
     at TasklistRecatPage
     decisionButton.click()
+    elite2Api.stubGetBasicOffenderDetails(700)
     to DecisionPage, '12'
 
     at DecisionPage
@@ -222,6 +227,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     when: 'I dont select anything'
@@ -265,6 +271,7 @@ class DecisionSpecification extends AbstractSpecification {
     riskProfilerApi.stubForTasklists('C0001AA', 'YOI Closed', false)
     browser.selectSecondPrisoner()
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
 
     when: 'Open option is submitted'

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/DecisionSpecification.groovy
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.cattool.pages.recat.RecategoriserHomePage
 import uk.gov.justice.digital.hmpps.cattool.specs.AbstractSpecification
 
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.FEMALE_RECAT_USER
 

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
@@ -37,6 +37,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     at TasklistRecatPage
 
     elite2Api.stubGetOffenderDetails(12)
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()
@@ -211,6 +212,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
     elite2Api.stubOffenceHistory('B2345YZ')
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
     at DecisionPage
     assert !indeterminateWarning.displayed
@@ -372,6 +374,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
     elite2Api.stubOffenceHistory('B2345YZ')
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()
@@ -533,6 +536,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     when: 'the recategoriser chooses cat D instead of C'
     submitButton.click()
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy
@@ -37,7 +37,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     at TasklistRecatPage
 
     elite2Api.stubGetOffenderDetails(12)
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()
@@ -212,7 +212,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
     elite2Api.stubOffenceHistory('B2345YZ')
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
     at DecisionPage
     assert !indeterminateWarning.displayed
@@ -374,7 +374,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     elite2Api.stubSentenceDataGetSingle('B2345YZ', '2014-11-23')
     elite2Api.stubOffenceHistory('B2345YZ')
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()
@@ -536,7 +536,7 @@ class OpenConditionsSpecification extends AbstractSpecification {
     when: 'the recategoriser chooses cat D instead of C'
     submitButton.click()
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(12)
     decisionButton.click()
     at DecisionPage
     categoryDOption.click()

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/WomenEstateRecatSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/WomenEstateRecatSpecification.groovy
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.cattool.specs.recat
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
-import uk.gov.justice.digital.hmpps.cattool.model.Caseload
 import uk.gov.justice.digital.hmpps.cattool.model.TestFixture
 import uk.gov.justice.digital.hmpps.cattool.pages.*
 import uk.gov.justice.digital.hmpps.cattool.pages.recat.DecisionPage
@@ -16,8 +15,6 @@ import uk.gov.justice.digital.hmpps.cattool.specs.AbstractSpecification
 
 import java.time.LocalDate
 
-import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.CATEGORISER_USER
-import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.RECATEGORISER_USER
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.FEMALE_SECURITY_USER
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.WOMEN_SUPERVISOR_USER
 
@@ -126,7 +123,7 @@ class WomenEstateRecatSpecification extends AbstractSpecification {
 
     and: 'I go to category decision page'
     at TasklistRecatPage
-    elite2Api.stubGetBasicOffenderDetails(700)
+    elite2Api.stubGetBasicOffenderDetails(700, '', 'PFI')
     decisionButton.click()
     at DecisionPage
     headerValue*.text() == fixture.MINI_HEADER1

--- a/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/WomenEstateRecatSpecification.groovy
+++ b/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/WomenEstateRecatSpecification.groovy
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.cattool.specs.recat
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import uk.gov.justice.digital.hmpps.cattool.model.Caseload
 import uk.gov.justice.digital.hmpps.cattool.model.TestFixture
 import uk.gov.justice.digital.hmpps.cattool.pages.*
 import uk.gov.justice.digital.hmpps.cattool.pages.recat.DecisionPage
@@ -15,6 +16,8 @@ import uk.gov.justice.digital.hmpps.cattool.specs.AbstractSpecification
 
 import java.time.LocalDate
 
+import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.CATEGORISER_USER
+import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.RECATEGORISER_USER
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.FEMALE_SECURITY_USER
 import static uk.gov.justice.digital.hmpps.cattool.model.UserAccount.WOMEN_SUPERVISOR_USER
 
@@ -123,6 +126,7 @@ class WomenEstateRecatSpecification extends AbstractSpecification {
 
     and: 'I go to category decision page'
     at TasklistRecatPage
+    elite2Api.stubGetBasicOffenderDetails(700)
     decisionButton.click()
     at DecisionPage
     headerValue*.text() == fixture.MINI_HEADER1

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
+        "@jest-mock/express": "^2.1.0",
         "@types/bunyan": "^1.8.11",
         "@types/bunyan-format": "^0.2.9",
         "@types/compression": "^1.7.5",
@@ -1198,6 +1199,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest-mock/express": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-2.1.0.tgz",
+      "integrity": "sha512-wwij1960SVxJL+v5Eqw3Akn3S5TLfCtHnFqs2K9Zto7RLU5I/7YhOsYDZQfNcnGyiBdisDz5iT21SRO1CVfvKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "^4.17.21"
       }
     },
     "node_modules/@jest/console": {

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "delay": 2500
   },
   "dependencies": {
+    "@joi/date": "^2.1.1",
     "@microsoft/applicationinsights-clickanalytics-js": "^3.1.0",
     "@microsoft/applicationinsights-web": "^3.1.0",
-    "@joi/date": "^2.1.1",
     "@ministryofjustice/frontend": "^2.1.0",
     "@snyk/protect": "^1.1293.0",
     "agentkeepalive": "^4.2.1",
@@ -126,6 +126,7 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
+    "@jest-mock/express": "^2.1.0",
     "@types/bunyan": "^1.8.11",
     "@types/bunyan-format": "^0.2.9",
     "@types/compression": "^1.7.5",

--- a/server/data/probationOffenderSearch/probationOffenderSearchApiClient.test.ts
+++ b/server/data/probationOffenderSearch/probationOffenderSearchApiClient.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import nock from 'nock'
 import config from '../../config'
 import clientBuilder from './probationOffenderSearchApiClient'

--- a/server/data/risksAndNeeds/risksAndNeedsApi.test.ts
+++ b/server/data/risksAndNeeds/risksAndNeedsApi.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import nock from 'nock'
 import config from '../../config'
 import clientBuilder from './risksAndNeedsApi'

--- a/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.test.ts
+++ b/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.test.ts
@@ -1,5 +1,4 @@
-import type { Response } from 'express'
-import { getMockReq } from '@jest-mock/express'
+import { getMockReq, getMockRes } from '@jest-mock/express'
 import { bookingExistsAtCurrentEstablishmentMiddleware } from './bookingExistsAtCurrentEstablishmentMiddleware'
 import { makeTestUserDto } from '../services/user/user.dto.test-factory'
 import { makeTestBasicOffenderDetailsDto } from '../services/offender/basicOffenderDetails.dto.test-factory'
@@ -10,31 +9,20 @@ const mockUserService = {
 const mockOffenderService = {
   getBasicOffenderDetails: jest.fn(),
 }
+const { res, clearMockRes } = getMockRes({ locals: {} })
 const testAgencyId = 'TEST'
 const testParams = { bookingId: '123456' }
 afterEach(() => {
   jest.resetAllMocks()
+  clearMockRes()
 })
 
 describe('bookingExistsAtCurrentEstablishmentMiddleware', () => {
   const next = jest.fn()
   const middleware = bookingExistsAtCurrentEstablishmentMiddleware(mockUserService, mockOffenderService)
 
-  test('it works correctly with matching agency IDs', async () => {
-    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
-    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
-      makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
-    )
-
-    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
-
-    expect(mockUserService.getUser).toBeCalledTimes(1)
-    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
-    expect(next).toBeCalledTimes(1)
-  })
-
   test('it fails when there is no booking ID', async () => {
-    await middleware(getMockReq({ params: {} }), { locals: {} } as Response, next)
+    await middleware(getMockReq(), res, next)
 
     expect(mockUserService.getUser).not.toHaveBeenCalled()
     expect(mockOffenderService.getBasicOffenderDetails).not.toHaveBeenCalled()
@@ -42,50 +30,60 @@ describe('bookingExistsAtCurrentEstablishmentMiddleware', () => {
     expect(next).toBeCalledWith(new Error('bookingExistsAtCurrentEstablishmentMiddleware: No booking id in params'))
   })
 
-  test('it fails when the agency IDs do not match', async () => {
-    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
-    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(makeTestBasicOffenderDetailsDto({ agencyId: 'BLA' }))
-    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+  describe('with booking ID', () => {
+    afterEach(() => {
+      expect(mockUserService.getUser).toBeCalledTimes(1)
+      expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
+      expect(next).toBeCalledTimes(1)
+    })
 
-    expect(mockUserService.getUser).toBeCalledTimes(1)
-    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
-    expect(next).toBeCalledTimes(1)
-    expect(next).toBeCalledWith(
-      new Error(
-        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+    test('it works correctly with matching agency IDs', async () => {
+      mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+      mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
+        makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
       )
-    )
-  })
 
-  test('it handles undefined response for getUser', async () => {
-    mockUserService.getUser.mockResolvedValue(undefined)
-    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
-      makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
-    )
-    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+      await middleware(getMockReq({ params: testParams }), res, next)
+    })
 
-    expect(mockUserService.getUser).toBeCalledTimes(1)
-    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
-    expect(next).toBeCalledTimes(1)
-    expect(next).toBeCalledWith(
-      new Error(
-        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+    test('it fails when the agency IDs do not match', async () => {
+      mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+      mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
+        makeTestBasicOffenderDetailsDto({ agencyId: 'BLA' })
       )
-    )
-  })
+      await middleware(getMockReq({ params: testParams }), res, next)
 
-  test('it handles undefined response for getBasicOffenderDwetails', async () => {
-    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
-    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(undefined)
-    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
-
-    expect(mockUserService.getUser).toBeCalledTimes(1)
-    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
-    expect(next).toBeCalledTimes(1)
-    expect(next).toBeCalledWith(
-      new Error(
-        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+      expect(next).toBeCalledWith(
+        new Error(
+          'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+        )
       )
-    )
+    })
+
+    test('it handles undefined response for getUser', async () => {
+      mockUserService.getUser.mockResolvedValue(undefined)
+      mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
+        makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
+      )
+      await middleware(getMockReq({ params: testParams }), res, next)
+
+      expect(next).toBeCalledWith(
+        new Error(
+          'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+        )
+      )
+    })
+
+    test('it handles undefined response for getBasicOffenderDetails', async () => {
+      mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+      mockOffenderService.getBasicOffenderDetails.mockResolvedValue(undefined)
+      await middleware(getMockReq({ params: testParams }), res, next)
+
+      expect(next).toBeCalledWith(
+        new Error(
+          'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+        )
+      )
+    })
   })
 })

--- a/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.test.ts
+++ b/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.test.ts
@@ -1,0 +1,91 @@
+import type { Response } from 'express'
+import { getMockReq } from '@jest-mock/express'
+import { bookingExistsAtCurrentEstablishmentMiddleware } from './bookingExistsAtCurrentEstablishmentMiddleware'
+import { makeTestUserDto } from '../services/user/user.dto.test-factory'
+import { makeTestBasicOffenderDetailsDto } from '../services/offender/basicOffenderDetails.dto.test-factory'
+
+const mockUserService = {
+  getUser: jest.fn(),
+}
+const mockOffenderService = {
+  getBasicOffenderDetails: jest.fn(),
+}
+const testAgencyId = 'TEST'
+const testParams = { bookingId: '123456' }
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('bookingExistsAtCurrentEstablishmentMiddleware', () => {
+  const next = jest.fn()
+  const middleware = bookingExistsAtCurrentEstablishmentMiddleware(mockUserService, mockOffenderService)
+
+  test('it works correctly with matching agency IDs', async () => {
+    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
+      makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
+    )
+
+    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+
+    expect(mockUserService.getUser).toBeCalledTimes(1)
+    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
+    expect(next).toBeCalledTimes(1)
+  })
+
+  test('it fails when there is no booking ID', async () => {
+    await middleware(getMockReq({ params: {} }), { locals: {} } as Response, next)
+
+    expect(mockUserService.getUser).not.toHaveBeenCalled()
+    expect(mockOffenderService.getBasicOffenderDetails).not.toHaveBeenCalled()
+    expect(next).toBeCalledTimes(1)
+    expect(next).toBeCalledWith(new Error('bookingExistsAtCurrentEstablishmentMiddleware: No booking id in params'))
+  })
+
+  test('it fails when the agency IDs do not match', async () => {
+    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(makeTestBasicOffenderDetailsDto({ agencyId: 'BLA' }))
+    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+
+    expect(mockUserService.getUser).toBeCalledTimes(1)
+    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
+    expect(next).toBeCalledTimes(1)
+    expect(next).toBeCalledWith(
+      new Error(
+        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+      )
+    )
+  })
+
+  test('it handles undefined response for getUser', async () => {
+    mockUserService.getUser.mockResolvedValue(undefined)
+    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(
+      makeTestBasicOffenderDetailsDto({ agencyId: testAgencyId })
+    )
+    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+
+    expect(mockUserService.getUser).toBeCalledTimes(1)
+    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
+    expect(next).toBeCalledTimes(1)
+    expect(next).toBeCalledWith(
+      new Error(
+        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+      )
+    )
+  })
+
+  test('it handles undefined response for getBasicOffenderDwetails', async () => {
+    mockUserService.getUser.mockResolvedValue(makeTestUserDto({ activeCaseLoad: { caseLoadId: testAgencyId } }))
+    mockOffenderService.getBasicOffenderDetails.mockResolvedValue(undefined)
+    await middleware(getMockReq({ params: testParams }), { locals: {} } as Response, next)
+
+    expect(mockUserService.getUser).toBeCalledTimes(1)
+    expect(mockOffenderService.getBasicOffenderDetails).toBeCalledTimes(1)
+    expect(next).toBeCalledTimes(1)
+    expect(next).toBeCalledWith(
+      new Error(
+        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+      )
+    )
+  })
+})

--- a/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.ts
+++ b/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, Response } from 'express'
+import log from '../../log'
+
+export const bookingExistsAtCurrentEstablishmentMiddleware =
+  (userService, offendersService) =>
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { bookingId } = req.params
+    if (typeof bookingId === 'undefined') {
+      const error = new Error('bookingExistsAtCurrentEstablishmentMiddleware: No booking id in params')
+      log.error(error.message)
+      next(error)
+      return
+    }
+    const user = await userService.getUser(res.locals)
+    res.locals.user = { ...user, ...res.locals?.user }
+    const basicOffenderDetails = await offendersService.getBasicOffenderDetails(res.locals, bookingId)
+    res.locals.basicOffenderDetails = basicOffenderDetails
+    if (user?.activeCaseLoad?.caseLoadId !== basicOffenderDetails?.agencyId) {
+      const error = new Error(
+        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+      )
+      log.error(error.message)
+      next(error)
+      return
+    }
+
+    next()
+  }
+
+export default bookingExistsAtCurrentEstablishmentMiddleware

--- a/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.ts
+++ b/server/middleware/bookingExistsAtCurrentEstablishmentMiddleware.ts
@@ -17,7 +17,7 @@ export const bookingExistsAtCurrentEstablishmentMiddleware =
     res.locals.basicOffenderDetails = basicOffenderDetails
     if (user?.activeCaseLoad?.caseLoadId !== basicOffenderDetails?.agencyId) {
       const error = new Error(
-        'bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload'
+        `bookingExistsAtCurrentEstablishmentMiddleware: booking agency ID does not match to the active caseload`
       )
       log.error(error.message)
       next(error)

--- a/server/routes/recat.js
+++ b/server/routes/recat.js
@@ -15,6 +15,9 @@ const recat = require('../config/recat')
 const Status = require('../utils/statusEnum')
 const RiskChangeStatus = require('../utils/riskChangeStatusEnum')
 const log = require('../../log')
+const {
+  bookingExistsAtCurrentEstablishmentMiddleware,
+} = require('../middleware/bookingExistsAtCurrentEstablishmentMiddleware')
 
 const formConfig = {
   recat,
@@ -286,9 +289,12 @@ module.exports = function Index({
 
   router.post(
     '/decision/:bookingId',
+    bookingExistsAtCurrentEstablishmentMiddleware(userService, offendersService),
     asyncMiddlewareInDatabaseTransaction(async (req, res, transactionalDbClient) => {
-      const user = await userService.getUser(res.locals)
-      res.locals.user = { ...user, ...res.locals.user }
+      if (!res.locals.user) {
+        const user = await userService.getUser(res.locals)
+        res.locals.user = { ...user, ...res.locals.user }
+      }
       const { bookingId } = req.params
       const section = 'recat'
       const form = 'decision'

--- a/server/services/offender/basicOffenderDetails.dto.test-factory.ts
+++ b/server/services/offender/basicOffenderDetails.dto.test-factory.ts
@@ -1,0 +1,9 @@
+import { BasicOffenderDetailsDto } from './basicOffenderDetails.dto'
+
+export const makeTestBasicOffenderDetailsDto = (
+  basicOffenderDetailsDto: Partial<BasicOffenderDetailsDto>
+): BasicOffenderDetailsDto => ({
+  agencyId: basicOffenderDetailsDto.agencyId,
+})
+
+export default makeTestBasicOffenderDetailsDto

--- a/server/services/offender/basicOffenderDetails.dto.ts
+++ b/server/services/offender/basicOffenderDetails.dto.ts
@@ -1,0 +1,3 @@
+export interface BasicOffenderDetailsDto {
+  agencyId: string
+}

--- a/server/services/user/user.dto.test-factory.ts
+++ b/server/services/user/user.dto.test-factory.ts
@@ -1,0 +1,9 @@
+import { UserDto } from './user.dto'
+
+export const makeTestUserDto = (userDto: Partial<UserDto>): UserDto => ({
+  activeCaseLoad: {
+    caseLoadId: userDto.activeCaseLoad.caseLoadId ?? 'TEST',
+  },
+})
+
+export default makeTestUserDto

--- a/server/services/user/user.dto.ts
+++ b/server/services/user/user.dto.ts
@@ -1,0 +1,5 @@
+export interface UserDto {
+  activeCaseLoad: {
+    caseLoadId: string
+  }
+}

--- a/test/routes/recat.test.js
+++ b/test/routes/recat.test.js
@@ -15,6 +15,10 @@ jest.doMock('jwt-decode', () => jest.fn(() => ({ authorities: roles })))
 
 const createRouter = require('../../server/routes/recat')
 const { makeTestFeatureFlagDto } = require('../../server/middleware/featureFlag.test-factory')
+const { makeTestUserDto } = require('../../server/services/user/user.dto.test-factory')
+const {
+  makeTestBasicOffenderDetailsDto,
+} = require('../../server/services/offender/basicOffenderDetails.dto.test-factory')
 
 const formConfig = {
   recat,
@@ -57,6 +61,7 @@ const offendersService = {
   createOrUpdateCategorisation: jest.fn(),
   getPrisonerBackground: jest.fn(),
   getRiskChangeForOffender: jest.fn(),
+  getBasicOffenderDetails: jest.fn(),
 }
 
 const userService = {
@@ -571,6 +576,18 @@ describe('POST /form/recat/decision', () => {
       displayName: 'Tim Handle',
       displayStatus: 'Any other status',
     })
+    offendersService.getBasicOffenderDetails.mockResolvedValue(
+      makeTestBasicOffenderDetailsDto({
+        agencyId: 'TEST',
+      })
+    )
+    userService.getUser.mockResolvedValue(
+      makeTestUserDto({
+        activeCaseLoad: {
+          caseLoadId: 'TEST',
+        },
+      })
+    )
     return request(app)
       .post(`/${formName}/12345`)
       .send(userInput)


### PR DESCRIPTION
There was a bug where a user opened a recat review, then switched caseload in another tab, and was then presented with the female estate pages and submitted a category decision with a female code for a male prisoner causing a few strange issues. This is adding a middleware which will blow up if the bookingId in the path is for a prisoner at an establishment which doesn't match the current active caseload ID. I've added it to the decision endpoint but it could be added to other endpoints.