### PR TITLE
[SI-1247] Allow deploy of develop to preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,16 @@ workflows:
             - hmpps-common-vars
           requires:
             - dev_branch_build_docker
+      - hmpps/deploy_env:
+          <<: *develop_branch
+          name: dev_branch_deploy_preprod
+          env: "preprod"
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.nonprod-releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+          requires:
+            - dev_branch_build_docker
       - hmpps/build_docker:
           <<: *main_branch
           name: build_docker


### PR DESCRIPTION
I need to test the outcome of an offender having a `null` return value for their `nextReviewDate` for a call to prison api. 

At present all offenders on the recat list will always have a `nextReviewDate`. We think that a possible solution to SI-607 is to `null` that date. However, that is a larger API change (outside our team) and may not work. This change is to allow a non-pipeline blocking test in PreProd only.

We specifically need to test this against two prisoners flagged via app support in PVI. 