### PR TITLE
[SI-1317] Migrate openConditions groovy test to cypress - second test only

### DIFF
--- a/integration_tests/e2e/recat/openConditions.cy.ts
+++ b/integration_tests/e2e/recat/openConditions.cy.ts
@@ -1,5 +1,5 @@
 import moment from 'moment/moment'
-import { RECATEGORISER_USER } from '../../factory/user'
+import { RECATEGORISER_USER, SUPERVISOR_USER } from '../../factory/user'
 import { CATEGORISATION_TYPE } from '../../support/categorisationType'
 import { AGENCY_LOCATION } from '../../factory/agencyLocation'
 import STATUS from '../../../server/utils/statusEnum'
@@ -18,13 +18,29 @@ import RiskLevelsPage from '../../pages/form/openConditions/riskLevels'
 import OpenConditionsNotRecommended from '../../pages/form/openConditions/notRecommendedPage'
 import { compareObjects, isToday } from '../../support/utilities'
 import ReviewRecatPage from '../../pages/form/recat/reviewRecatPage'
+import CategoriserSubmittedPage from '../../pages/taskList/categoriserSubmitted'
+import RecatAwaitingApprovalPage from '../../pages/recatAwaitingSupervisorApproval/awaitingApprovalView'
+import SupervisorHomePage from '../../pages/supervisor/home'
+import SupervisorReviewPage from '../../pages/form/supervisor/review'
+import SupervisorReviewOutcomePage from '../../pages/form/supervisor/outcome'
+import SupervisorDonePage from '../../pages/supervisor/done'
+import ApprovedViewPage from '../../pages/form/approvedView'
+import RecatApprovedViewPage from '../../pages/form/recatApprovedView'
 
 describe('Open Conditions', () => {
   let sentenceStartDates: Record<'B2345XY' | 'B2345YZ', Date>
+  let today: Date
 
   beforeEach(() => {
     cy.task('reset')
     cy.task('setUpDb')
+
+    sentenceStartDates = {
+      B2345XY: new Date('2019-01-28'),
+      B2345YZ: new Date('2019-01-31'),
+    }
+
+    today = new Date()
   })
 
   it('The happy path is correct for recategoriser setting cat D, all yeses, then cancelling open conditions', () => {
@@ -58,11 +74,6 @@ describe('Open Conditions', () => {
       assignedUserId: null,
       approvedBy: null,
     })
-
-    sentenceStartDates = {
-      B2345XY: new Date('2019-01-28'),
-      B2345YZ: new Date('2019-01-31'),
-    }
 
     // when: 'The categoriser sets cat D'
     cy.task('stubRecategorise')
@@ -181,7 +192,6 @@ describe('Open Conditions', () => {
     riskOfEscapingOrAbscondingPage.continueButton().click()
 
     cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 12 }, (data: DbQueryResult) => {
-      cy.log('Check the prisoner data before changing category, should retain "open conditions" info')
       const dbRecord = data.rows[0]
       delete dbRecord.start_date
 
@@ -257,10 +267,8 @@ describe('Open Conditions', () => {
       delete expected.start_date
 
       const assessmentStartedToday = isToday(dbRecord.start_date)
-      cy.log('assessmentStartedToday matches', assessmentStartedToday)
 
       const dbRecordMatchesExpected = compareObjects(expected, dbRecord)
-      cy.log('dbRecordMatchesExpected', dbRecordMatchesExpected)
 
       return dbRecordMatchesExpected && assessmentStartedToday
     })
@@ -316,7 +324,6 @@ describe('Open Conditions', () => {
     ])
 
     cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 12 }, (data: DbQueryResult) => {
-      cy.log('Check the prisoner data after changing category, should have removed "open conditions" info')
       const dbRecord = data.rows[0]
       delete dbRecord.start_date
 
@@ -440,10 +447,8 @@ describe('Open Conditions', () => {
       delete expected.start_date
 
       const assessmentStartedToday = isToday(dbRecord.start_date)
-      cy.log('assessmentStartedToday matches', assessmentStartedToday)
 
       const dbRecordMatchesExpected = compareObjects(expected, dbRecord)
-      cy.log('dbRecordMatchesExpected', dbRecordMatchesExpected)
 
       return dbRecordMatchesExpected && assessmentStartedToday
     })
@@ -454,4 +459,419 @@ describe('Open Conditions', () => {
 
   // it("should validate the Further Charges page", () => {
   // });
+
+  it('The happy path is correct for recategoriser setting cat D, all nos', () => {
+    cy.task('insertFormTableDbRow', {
+      id: -1,
+      bookingId: 12,
+      // nomisSequenceNumber: 1,
+      catType: CATEGORISATION_TYPE.RECAT,
+      offenderNo: 'B2345YZ',
+      sequenceNumber: 1,
+      status: STATUS.STARTED.name,
+      prisonId: AGENCY_LOCATION.LEI.id,
+      startDate: new Date(),
+      formResponse: {
+        recat: {
+          decision: { category: 'C' },
+          oasysInput: { date: '14/12/2019', oasysRelevantInfo: 'No' },
+          securityInput: { securityInputNeeded: 'Yes', securityNoteNeeded: 'No' },
+          nextReviewDate: { date: '14/12/2019' },
+          prisonerBackground: { offenceDetails: 'offence Details text' },
+          riskAssessment: {
+            lowerCategory: 'lower security category text',
+            otherRelevant: 'Yes',
+            higherCategory: 'higher security category text',
+            otherRelevantText: 'other relevant information',
+          },
+        },
+      },
+      securityReviewedBy: null,
+      securityReviewedDate: null,
+      assignedUserId: null,
+      approvedBy: null,
+    })
+
+    // when: 'The categoriser overrides to D'
+    cy.task('stubRecategorise')
+    cy.task('stubGetPrisonerSearchPrisoners')
+    cy.task('stubSentenceData', {
+      offenderNumbers: ['B2345XY', 'B2345YZ'],
+      bookingIds: [11, 12],
+      startDates: [today, today],
+    })
+    cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
+    cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
+    cy.task('stubOffenceHistory', { offenderNumber: 'B2345YZ' })
+    cy.task('stubGetOffenderDetails', {
+      bookingId: 12,
+      offenderNo: 'B2345YZ',
+      youngOffender: false,
+      indeterminateSentence: false,
+    })
+    cy.task('stubGetSocProfile', {
+      offenderNo: 'B2345YZ',
+      category: 'C',
+      transferToSecurity: false,
+    })
+    cy.task('stubGetExtremismProfile', {
+      offenderNo: 'B2345YZ',
+      category: 'C',
+      increasedRisk: true,
+      notifyRegionalCTLead: false,
+    })
+    cy.task('stubGetEscapeProfile', {
+      offenderNo: 'B2345YZ',
+      category: 'C',
+      onEscapeList: true,
+      activeOnEscapeList: true,
+    })
+    cy.task('stubGetViolenceProfile', {
+      offenderNo: 'B2345YZ',
+      category: 'C',
+      veryHighRiskViolentOffender: true,
+      notifySafetyCustodyLead: true,
+      displayAssaults: false,
+    })
+    cy.task('stubAgencyDetails', { agency: 'LPI' })
+
+    cy.stubLogin({
+      user: RECATEGORISER_USER,
+    })
+    cy.signIn()
+
+    const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
+    recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
+
+    const tasklistRecatPage = Page.verifyOnPage(TasklistRecatPage)
+    tasklistRecatPage.decisionButton().click()
+
+    const decisionPage = Page.verifyOnPage(DecisionPage)
+    decisionPage.indeterminateWarning().should('not.exist')
+    decisionPage.catDOption().click()
+    decisionPage.submitButton().click()
+
+    // Open Conditions Added Page
+    const openConditionsAddedPage = Page.verifyOnPage(OpenConditionsAdded)
+    openConditionsAddedPage.returnToRecatTasklistButton(12).click()
+
+    // 'the tasklist recat page is displayed with open conditions section added'
+    tasklistRecatPage.openConditionsButton().should('exist')
+
+    // 'open conditions forms are completed'
+    tasklistRecatPage.openConditionsButton().click()
+
+    const tprsPage = Page.verifyOnPage(TprsPage)
+    tprsPage.selectTprsRadioButton('NO')
+    tprsPage.continueButton().click()
+
+    const earliestReleasePage = Page.verifyOnPage(EarliestReleaseDatePage)
+    earliestReleasePage.selectEarliestReleaseDateRadioButton('NO')
+    earliestReleasePage.continueButton().click()
+
+    const victimContactSchemaPage = Page.verifyOnPage(VictimContactSchemePage)
+    victimContactSchemaPage.selectVictimContactSchemeRadioButton('NO')
+    victimContactSchemaPage.continueButton().click()
+
+    const foreignNationalPage = Page.verifyOnPage(ForeignNationalPage)
+    foreignNationalPage.selectForeignNationalRadioButton('NO')
+    foreignNationalPage.continueButton().click()
+
+    const riskOfHarmPage = Page.verifyOnPage(RiskOfSeriousHarmPage)
+    riskOfHarmPage.selectRiskOfSeriousHarmRadioButton('NO')
+    riskOfHarmPage.continueButton().click()
+
+    const furtherChargesPage = Page.verifyOnPage(FurtherChargesPage)
+    furtherChargesPage.selectFurtherChargesRadioButton('NO')
+    furtherChargesPage.continueButton().click()
+
+    const riskOfEscapingOrAbscondingPage = Page.verifyOnPage(RiskLevelsPage)
+    riskOfEscapingOrAbscondingPage.selectRiskLevelsRadioButton('NO')
+    riskOfEscapingOrAbscondingPage.continueButton().click()
+
+    // 'tasklist page is displayed with the open conditions section completed'
+    tasklistRecatPage.openConditionsButton().should('contain.text', 'Edit')
+    tasklistRecatPage.checkAndSubmitButton(12).click()
+
+    // 'the review page is displayed and Data is stored correctly. Data is persisted (and displayed) - regardless of the decision to end the open conditions flow'
+    const reviewRecatPage = Page.verifyOnPage(ReviewRecatPage)
+    reviewRecatPage.changeLinks().should('have.length', 13)
+    reviewRecatPage.validateEarliestReleaseDateSummary([
+      { question: '3 or more years until earliest release date?', expectedAnswer: 'No' },
+      { question: 'Reasons that justify moving to open conditions?', expectedAnswer: 'Not applicable' },
+    ])
+    reviewRecatPage.validateVictimContactSchemeSummary([
+      { question: 'Have any victims of the crime opted-in to the Victim Contact Scheme?', expectedAnswer: 'No' },
+      { question: 'Have you contacted the Victim Liaison Officer (VLO)?', expectedAnswer: 'Not applicable' },
+    ])
+    reviewRecatPage.validateForeignNationalSummary([
+      { question: 'Are they a foreign national?', expectedAnswer: 'No' },
+      { question: 'Have the Home Office confirmed their immigration status?', expectedAnswer: 'Not applicable' },
+      { question: 'Do they have a liability for deportation?', expectedAnswer: 'Not applicable' },
+      { question: 'Have they been through all appeals process in the UK?', expectedAnswer: 'Not applicable' },
+    ])
+    reviewRecatPage.validateRiskOfHarmSummary([
+      { question: 'Risk of serious harm to the public?', expectedAnswer: 'No' },
+      { question: 'Can this risk be managed?', expectedAnswer: 'Not applicable' },
+    ])
+    reviewRecatPage.validateRiskLevelSummary([
+      { question: 'Likely to abscond or abuse open conditions?', expectedAnswer: 'No' },
+    ])
+    reviewRecatPage.validateCategoryDecisionSummary([
+      { question: 'What security category is most suitable for this person?', expectedAnswer: 'Category D' },
+    ])
+
+    cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 12 }, (data: DbQueryResult) => {
+      const dbRecord = data.rows[0]
+      delete dbRecord.start_date
+
+      const expected = {
+        id: -1,
+        form_response: {
+          recat: {
+            decision: { category: 'D' },
+            oasysInput: { date: '14/12/2019', oasysRelevantInfo: 'No' },
+            securityInput: { securityNoteNeeded: 'No', securityInputNeeded: 'Yes' },
+            nextReviewDate: { date: '14/12/2019' },
+            riskAssessment: {
+              lowerCategory: 'lower security category text',
+              otherRelevant: 'Yes',
+              higherCategory: 'higher security category text',
+              otherRelevantText: 'other relevant information',
+            },
+            prisonerBackground: { offenceDetails: 'offence Details text' },
+          },
+          openConditions: {
+            tprs: { tprsSelected: 'No' },
+            riskLevels: { likelyToAbscond: 'No' },
+            riskOfHarm: { seriousHarm: 'No' },
+            furtherCharges: { furtherCharges: 'No' },
+            foreignNational: { isForeignNational: 'No' },
+            earliestReleaseDate: { threeOrMoreYears: 'No' },
+            victimContactScheme: { vcsOptedFor: 'No' },
+          },
+          openConditionsRequested: true,
+        },
+        booking_id: 12,
+        user_id: null,
+        status: 'STARTED',
+        assigned_user_id: null,
+        referred_date: null,
+        referred_by: null,
+        sequence_no: 1,
+        risk_profile: {
+          socProfile: {
+            nomsId: 'B2345YZ',
+            riskType: 'SOC',
+            transferToSecurity: false,
+            provisionalCategorisation: 'C',
+          },
+          escapeProfile: {
+            nomsId: 'B2345YZ',
+            riskType: 'ESCAPE',
+            activeEscapeList: true,
+            activeEscapeRisk: true,
+            escapeListAlerts: [
+              {
+                active: true,
+                comment: 'First xel comment',
+                expired: false,
+                alertCode: 'XEL',
+                dateCreated: '2016-09-14',
+                alertCodeDescription: 'Escape List',
+              },
+              {
+                active: false,
+                comment:
+                  '\nSecond xel comment with lengthy text comment with lengthy text comment with lengthy text comment with lengthy text\ncomment with lengthy text comment with lengthy text comment with lengthy text\ncomment with lengthy text comment with lengthy text comment with lengthy text\ncomment with lengthy text comment with lengthy text comment with lengthy text\n',
+                expired: true,
+                alertCode: 'XEL',
+                dateCreated: '2016-09-15',
+                alertCodeDescription: 'Escape List',
+              },
+            ],
+            escapeRiskAlerts: [
+              {
+                active: true,
+                comment: 'First xer comment',
+                expired: false,
+                alertCode: 'XER',
+                dateCreated: '2016-09-16',
+                alertCodeDescription: 'Escape Risk',
+              },
+            ],
+            provisionalCategorisation: 'C',
+          },
+          violenceProfile: {
+            nomsId: 'B2345YZ',
+            riskType: 'VIOLENCE',
+            displayAssaults: false,
+            numberOfAssaults: 5,
+            notifySafetyCustodyLead: true,
+            numberOfSeriousAssaults: 2,
+            provisionalCategorisation: 'C',
+            numberOfNonSeriousAssaults: 3,
+            veryHighRiskViolentOffender: true,
+          },
+          extremismProfile: {
+            nomsId: 'B2345YZ',
+            riskType: 'EXTREMISM',
+            notifyRegionalCTLead: false,
+            increasedRiskOfExtremism: true,
+            provisionalCategorisation: 'C',
+          },
+        },
+        prison_id: 'LEI',
+        offender_no: 'B2345YZ',
+        security_reviewed_by: null,
+        security_reviewed_date: null,
+        approval_date: null,
+        cat_type: 'RECAT',
+        nomis_sequence_no: null,
+        assessment_date: null,
+        approved_by: null,
+        assessed_by: null,
+        review_reason: 'DUE',
+        due_by_date: null,
+        cancelled_date: null,
+        cancelled_by: null,
+      }
+
+      const dbRecordMatchesExpected = compareObjects(expected, dbRecord)
+      return dbRecordMatchesExpected
+    })
+
+    // 'I confirm the cat D category'
+    cy.task('stubCategorise', {
+      bookingId: 12,
+      category: 'D',
+      committee: 'OCA',
+      nextReviewDate: '2019-12-14',
+      comment: 'comment',
+      placementAgencyId: 'LEI',
+      sequenceNumber: 5,
+    })
+    reviewRecatPage.saveAndSubmitButton().click()
+
+    // 'the category is submitted'
+    Page.verifyOnPage(CategoriserSubmittedPage)
+    cy.task('stubRecategorise', {
+      recategorisations: [
+        {
+          bookingId: 12,
+          offenderNo: 'B2345XY',
+          firstName: 'PENELOPE',
+          lastName: 'PITSTOP',
+          category: 'C',
+          nextReviewDate: moment(today).subtract(4, 'days').format('yyyy-MM-dd'),
+          assessStatus: 'P',
+        },
+        {
+          bookingId: 11,
+          offenderNo: 'B2345YZ',
+          firstName: 'ANT',
+          lastName: 'HILLMOB',
+          category: 'D',
+          nextReviewDate: moment(today).subtract(2, 'days').format('yyyy-MM-dd'),
+          assessStatus: 'A',
+        },
+      ],
+    })
+
+    //  'The record is viewed by the recategoriser'
+    cy.visit(RecategoriserHomePage.baseUrl)
+    Page.verifyOnPage(RecategoriserHomePage)
+    recategoriserHomePage.viewReviewAwaitingApprovalForPrisoner(12)
+
+    // 'The correct category is retrieved and data is correct'
+    const recatAwaitingApprovalPage = Page.verifyOnPage(RecatAwaitingApprovalPage)
+    recatAwaitingApprovalPage.getCategoryForApproval().contains('Category for approval is open category')
+    recatAwaitingApprovalPage.validateEarliestReleaseDateSummary([
+      { question: '3 or more years until earliest release date?', expectedAnswer: 'No' },
+      { question: 'Reasons that justify moving to open conditions?', expectedAnswer: 'Not applicable' },
+    ])
+
+    cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 12 }, (data: DbQueryResult) => {
+      const dbRecord = data.rows[0]
+
+      expect(dbRecord.assessed_by).equals('RECATEGORISER_USER')
+      expect(dbRecord.approved_by).equals(null)
+      expect(dbRecord.assessment_date).not.equals(null)
+      expect(dbRecord.nomis_sequence_no).equals(5)
+      expect(dbRecord.status).equals('AWAITING_APPROVAL')
+
+      return true
+    })
+
+    // 'the supervisor reviews and accepts the cat D'
+    recatAwaitingApprovalPage.signOut().click()
+
+    cy.task('stubUncategorisedAwaitingApproval')
+    cy.task('stubSentenceData', {
+      offenderNumbers: ['B2345XY'],
+      bookingIds: [11],
+      startDates: [sentenceStartDates.B2345XY],
+    })
+    cy.task('stubAssessments', {
+      offenderNumber: 'dummy',
+    })
+
+    cy.stubLogin({
+      user: SUPERVISOR_USER,
+    })
+    cy.signIn()
+
+    const supervisorHomePage = Page.verifyOnPage(SupervisorHomePage)
+    supervisorHomePage.startReviewForPrisoner(12)
+
+    cy.task('stubSupervisorApprove')
+
+    const supervisorReviewPage = Page.verifyOnPage(SupervisorReviewPage)
+    supervisorReviewPage.validateCategorisersRecommendedCategory('The categoriser recommends open category')
+    supervisorReviewPage.selectAgreeWithProvisionalCategoryRadioButton('YES')
+    supervisorReviewPage.submitButton().click()
+
+    // 'Data is stored correctly'
+
+    cy.assertDBWithRetries('selectFormTableDbRow', { bookingId: 12 }, (data: DbQueryResult) => {
+      const dbRecord = data.rows[0]
+
+      expect(dbRecord.assessed_by).equals('RECATEGORISER_USER')
+      expect(dbRecord.approved_by).equals('SUPERVISOR_USER')
+      expect(dbRecord.assessment_date).not.equals(null)
+      expect(dbRecord.nomis_sequence_no).equals(5)
+      expect(dbRecord.status).equals('APPROVED')
+      expect(dbRecord.form_response.recat.decision).to.deep.equal({ category: 'D' })
+      expect(dbRecord.form_response.supervisor).to.deep.equal({
+        review: { proposedCategory: 'D', supervisorCategoryAppropriate: 'Yes' },
+      })
+
+      return true
+    })
+
+    // 'the approved view page is shown'
+    const supervisorReviewOutcomePage = Page.verifyOnPage(SupervisorReviewOutcomePage)
+    supervisorReviewOutcomePage.finishButton().click()
+
+    cy.task('stubCategorised', {
+      bookingIds: [12],
+    })
+    cy.task('stubGetStaffDetailsByUsernameList', { usernames: [SUPERVISOR_USER.username] })
+
+    Page.verifyOnPage(SupervisorHomePage)
+    supervisorHomePage.doneTabLink().click()
+
+    cy.task('stubAgencyDetails', { agency: 'LEI' })
+
+    const supervisorDonePage = Page.verifyOnPage(SupervisorDonePage)
+    supervisorDonePage.viewApprovedPrisonerButton({ bookingId: 12, sequenceNumber: 1 }).click()
+
+    const approvedViewRecatPage = Page.verifyOnPage(RecatApprovedViewPage)
+    approvedViewRecatPage.validateCategorisationWarnings([
+      'Open category',
+      'The categoriser recommends open category',
+      'The supervisor also recommends open category',
+    ])
+    approvedViewRecatPage.validateCommentsVisibility({ areVisible: false })
+  })
 })

--- a/integration_tests/e2e/recategoriserHome.cy.ts
+++ b/integration_tests/e2e/recategoriserHome.cy.ts
@@ -75,7 +75,7 @@ describe('Recategoriser Home page', () => {
         assessmentSeq: 18,
         assessStatus: 'P',
         category: 'C',
-        nextReviewDate: '2025-01-01',
+        nextReviewDate: '2045-01-01',
       }
 
       const sentenceStartDates = {

--- a/integration_tests/mockApis/elite2.ts
+++ b/integration_tests/mockApis/elite2.ts
@@ -990,7 +990,7 @@ const stubGetUserDetails = ({ user, caseloadId }: { user: UserAccount; caseloadI
     },
   })
 
-const stubGetStaffDetailsByUsernameList = ({ usernames = [] }): SuperAgentRequest =>
+const stubGetStaffDetailsByUsernameList = ({ usernames } = { usernames: [] }): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'POST',
@@ -1506,7 +1506,15 @@ const stubRecategorise = (
   return Promise.all([recategorisationsStub(agencyId), latestOnlyStub()])
 }
 
-const stubAdjudicationHearings = ({ agencyId, fromDate, toDate }: { agencyId: string, fromDate: string, toDate: string }): SuperAgentRequest =>
+const stubAdjudicationHearings = ({
+  agencyId,
+  fromDate,
+  toDate,
+}: {
+  agencyId: string
+  fromDate: string
+  toDate: string
+}): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'POST',

--- a/integration_tests/pages/form/baseApprovedView.ts
+++ b/integration_tests/pages/form/baseApprovedView.ts
@@ -1,0 +1,30 @@
+import Page from '../page'
+
+export default abstract class BaseApprovedViewPage extends Page {
+  validateCategorisationWarnings(warnings: string[]) {
+    warnings.forEach((warning, index) => {
+      cy.get(`.govuk-warning-text:eq(${index})`).should('contain.text', 'Warning')
+      cy.get(`.govuk-warning-text:eq(${index})`).should('contain.text', warning)
+    })
+  }
+
+  validateCommentsVisibility({ areVisible }: { areVisible: boolean }) {
+    cy.get('.forms-comments-text').should(areVisible ? 'exist' : 'not.exist')
+  }
+
+  validateOpenConditionsHeadingVisibility({ isVisible }: { isVisible: boolean }) {
+    cy.get('.openConditionsHeader').should(isVisible ? 'exist' : 'not.exist')
+  }
+
+  validateCategoriserComments({ expectedComments }: { expectedComments: string }) {
+    cy.get('#overriddenText').should('contain.text', expectedComments)
+  }
+
+  validateSupervisorComments({ expectedComments }: { expectedComments: string }) {
+    cy.get('#overriddenText-2').should('contain.text', expectedComments)
+  }
+
+  getBackToCaseListButton() {
+    return cy.get(`a[role='button']`).contains('Back to case list')
+  }
+}

--- a/integration_tests/pages/form/recat/decision/decisionPage.ts
+++ b/integration_tests/pages/form/recat/decision/decisionPage.ts
@@ -23,4 +23,5 @@ export default class DecisionPage extends Page {
   submitButton = (): PageElement => cy.get('button[type="submit"]')
   errorSummaries = (): PageElement => cy.get('ul.govuk-error-summary__list li')
   errors = (): PageElement => cy.get('.govuk-error-message')
+  indeterminateWarning = (): PageElement => cy.get('#indeterminateWarning')
 }

--- a/integration_tests/pages/form/recat/reviewRecatPage.ts
+++ b/integration_tests/pages/form/recat/reviewRecatPage.ts
@@ -54,4 +54,32 @@ export default class ReviewRecatPage extends Page {
       ...expected,
     ])
   }
+
+  validateEarliestReleaseDateSummary = (expected: DtDlQuestionExpectedAnswerPair[]) => {
+    this.validateDescriptionList('earliestReleaseDateSummary', [
+      { question: 'Earliest release date', expectedAnswer: '' },
+      ...expected,
+    ])
+  }
+
+  validateVictimContactSchemeSummary = (expected: DtDlQuestionExpectedAnswerPair[]) => {
+    this.validateDescriptionList('victimContactSchemeSummary', [
+      { question: 'Victim Contact Scheme (VCS)', expectedAnswer: '' },
+      ...expected,
+    ])
+  }
+
+  validateForeignNationalSummary = (expected: DtDlQuestionExpectedAnswerPair[]) => {
+    this.validateDescriptionList('foreignNationalSummary', [
+      { question: 'Foreign national', expectedAnswer: '' },
+      ...expected,
+    ])
+  }
+
+  validateRiskLevelSummary = (expected: DtDlQuestionExpectedAnswerPair[]) => {
+    this.validateDescriptionList('riskLevelSummary', [
+      { question: 'Risk of escaping or absconding', expectedAnswer: '' },
+      ...expected,
+    ])
+  }
 }

--- a/integration_tests/pages/form/recatApprovedView.ts
+++ b/integration_tests/pages/form/recatApprovedView.ts
@@ -1,10 +1,10 @@
 import Page from '../page'
 import BaseApprovedViewPage from './baseApprovedView'
 
-export default class ApprovedViewPage extends BaseApprovedViewPage {
+export default class RecatApprovedViewPage extends BaseApprovedViewPage {
   static baseUrl: string = '/form/approvedView'
 
   constructor() {
-    super('Categorisation outcome')
+    super('Categorisation review outcome')
   }
 }

--- a/integration_tests/pages/form/supervisor/review.ts
+++ b/integration_tests/pages/form/supervisor/review.ts
@@ -21,6 +21,7 @@ type WhichCategoryIsMoreAppropriateChoiceValues =
   | typeof whichCategoryIsMoreAppropriateRadioChoiceHtmlSelectors.CONSIDER_FOR_CLOSED
 
 const SELECTORS = {
+  CATEGORISER_RECOMMENDED_CATEGORY: '#categoriser-recommended-category',
   INDETERMINATE_WARNING: '#indeterminateWarning',
   OPEN_CONDITIONS: {
     INFO_MESSAGE: '#openConditionsInfoMessage',
@@ -144,5 +145,9 @@ export default class SupervisorReviewPage extends Page {
     }[]
   ) {
     super.validateErrorMessages(errorMessages)
+  }
+
+  validateCategorisersRecommendedCategory(expectedMessage: string) {
+    cy.get(SELECTORS.CATEGORISER_RECOMMENDED_CATEGORY).should('contain.text', expectedMessage)
   }
 }

--- a/integration_tests/pages/recatAwaitingSupervisorApproval/awaitingApprovalView.ts
+++ b/integration_tests/pages/recatAwaitingSupervisorApproval/awaitingApprovalView.ts
@@ -1,0 +1,19 @@
+import Page, { DtDlQuestionExpectedAnswerPair, PageElement } from '../page'
+import { LOW_RISK_OF_ESCAPE } from '../../../server/services/recategorisation/filter/recategorisationFilter'
+
+export default class RecatAwaitingApprovalPage extends Page {
+  static baseUrl: string = '/form/awaitingApprovalView'
+
+  constructor() {
+    super('Provisional categorisation')
+  }
+
+  getCategoryForApproval = (): PageElement => cy.get('#category-div')
+
+  validateEarliestReleaseDateSummary = (expected: DtDlQuestionExpectedAnswerPair[]) => {
+    this.validateDescriptionList('earliestReleaseDateSummary', [
+      { question: 'Earliest release date', expectedAnswer: '' },
+      ...expected,
+    ])
+  }
+}

--- a/integration_tests/pages/recategoriser/home.ts
+++ b/integration_tests/pages/recategoriser/home.ts
@@ -17,4 +17,7 @@ export default class RecategoriserHomePage extends BaseRecategoriserPage {
 
   continueReviewForPrisoner = (bookingId: number, reviewReason: 'DUE') =>
     cy.get(`a[href="/tasklistRecat/${bookingId}?reason=${reviewReason}"`).should('contain.text', 'Edit').click()
+
+  viewReviewAwaitingApprovalForPrisoner = (bookingId: number) =>
+    cy.get(`a[href="/form/awaitingApprovalView/${bookingId}"`).should('contain.text', 'View').click()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "audit-ci": "^6.6.1",
         "concurrently": "^8.2.2",
         "cookie-session": "^2.0.0",
-        "cypress": "^13.16.1",
+        "cypress": "^13.17.0",
         "cypress-multi-reporters": "^1.6.4",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -6078,6 +6078,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "audit-ci": "^6.6.1",
     "concurrently": "^8.2.2",
     "cookie-session": "^2.0.0",
-    "cypress": "^13.16.1",
+    "cypress": "^13.17.0",
     "cypress-multi-reporters": "^1.6.4",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/server/views/formPages/supervisor/recatReview.html
+++ b/server/views/formPages/supervisor/recatReview.html
@@ -29,7 +29,8 @@
     {% if isOpenCategory(currentCat) %}
       {% include "../../partials/tprsBanner.html" %}
     {% endif %}
-    <div class="govuk-warning-text forms-info-text warning-overrides govuk-!-margin-bottom-6">
+    <div class="govuk-warning-text forms-info-text warning-overrides govuk-!-margin-bottom-6"
+         id="categoriser-recommended-category">
       <span class="govuk-warning-text__icon" aria-hidden="true">{{ displayIcon(currentCat) }}</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-visually-hidden">Warning</span>


### PR DESCRIPTION
It's large because what it migrates from is equally very large - https://github.com/ministryofjustice/offender-categorisation/blob/main/integration-tests/src/test/groovy/uk/gov/justice/digital/hmpps/cattool/specs/recat/OpenConditionsSpecification.groovy#L203-L362