### PR TITLE
Si 1471 add additional logging for error due cats

### DIFF
--- a/server/data/prisonerSearch/prisonerSearch.dto.ts
+++ b/server/data/prisonerSearch/prisonerSearch.dto.ts
@@ -21,4 +21,5 @@ export interface PrisonerSearchDto {
   alerts: PrisonerSearchAlertDto[] | undefined
   currentIncentive: PrisonerSearchIncentiveLevelDto | undefined
   legalStatus: LegalStatus
+  recall: boolean | undefined
 }

--- a/server/data/prisonerSearchApi.js
+++ b/server/data/prisonerSearchApi.js
@@ -56,6 +56,7 @@ module.exports = context => {
             alerts: r.alerts,
             currentIncentive: r.currentIncentive,
             legalStatus: r.legalStatus,
+            recall: r.recall,
             offenderNo: r.prisonerNumber,
           })
         )

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -769,10 +769,14 @@ module.exports = function createOffendersService(
           return null
         }
 
-        const sentenceStartDate = prisonerSearchData.get(raw.bookingId)?.sentenceStartDate || null
-        if (sentenceStartDate == null || moment(sentenceStartDate).isAfter(moment(nomisRecord.assessmentDate))) {
+        const prisonerSearchRecord = prisonerSearchData.get(raw.bookingId) || null
+        if (
+          prisonerSearchRecord == null ||
+          prisonerSearchRecord.sentenceStartDate == null ||
+          moment(prisonerSearchRecord.sentenceStartDate).isAfter(moment(nomisRecord.assessmentDate))
+        ) {
           logger.info(
-            `recategorisationDashboardErrorInvestigation: ${nomisRecord.offenderNo}, assessmentDate = ${nomisRecord.assessmentDate}, sentence date = ${sentenceStartDate}, next review date = ${nomisRecord.nextReviewDate}`
+            `recategorisationDashboardErrorInvestigation: ${nomisRecord.offenderNo}, assessmentDate = ${nomisRecord.assessmentDate}, sentence date = ${prisonerSearchRecord.sentenceStartDate}, next review date = ${nomisRecord.nextReviewDate}, legalStatus = ${prisonerSearchRecord.legalStatus}, recall = ${prisonerSearchRecord.recall}`
           )
         }
 

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -776,7 +776,7 @@ module.exports = function createOffendersService(
           moment(prisonerSearchRecord.sentenceStartDate).isAfter(moment(nomisRecord.assessmentDate))
         ) {
           logger.info(
-            `recategorisationDashboardErrorInvestigation: ${nomisRecord.offenderNo}, assessmentDate = ${nomisRecord.assessmentDate}, sentence date = ${prisonerSearchRecord.sentenceStartDate}, next review date = ${nomisRecord.nextReviewDate}, legalStatus = ${prisonerSearchRecord.legalStatus}, recall = ${prisonerSearchRecord.recall}`
+            `recategorisationDashboardErrorInvestigation: ${nomisRecord.offenderNo}, assessmentDate = ${nomisRecord.assessmentDate}, sentence date = ${prisonerSearchRecord?.sentenceStartDate}, next review date = ${nomisRecord.nextReviewDate}, legalStatus = ${prisonerSearchRecord?.legalStatus}, recall = ${prisonerSearchRecord?.recall}`
           )
         }
 

--- a/server/services/recategorisation/prisonerSearch/recategorisationPrisonerSearch.dto.test-factory.ts
+++ b/server/services/recategorisation/prisonerSearch/recategorisationPrisonerSearch.dto.test-factory.ts
@@ -8,6 +8,7 @@ const makeTestRecategorisationPrisonerSearchDto = (
   currentIncentive: recategorisationPrisonerSearchDto.currentIncentive ?? undefined,
   legalStatus: recategorisationPrisonerSearchDto.legalStatus ?? 'SENTENCED',
   sentenceStartDate: recategorisationPrisonerSearchDto.sentenceStartDate ?? '2025-01-01',
+  recall: recategorisationPrisonerSearchDto.recall ?? false,
 })
 
 export default makeTestRecategorisationPrisonerSearchDto

--- a/server/services/recategorisation/prisonerSearch/recategorisationPrisonerSearch.dto.ts
+++ b/server/services/recategorisation/prisonerSearch/recategorisationPrisonerSearch.dto.ts
@@ -8,6 +8,7 @@ export interface RecategorisationPrisonerSearchDto {
   currentIncentive: PrisonerSearchIncentiveLevelDto | undefined
   legalStatus: LegalStatus
   sentenceStartDate: string | undefined
+  recall: boolean | undefined
 }
 
 export const mapPrisonerSearchDtoToRecategorisationPrisonerSearchDto = (
@@ -18,4 +19,5 @@ export const mapPrisonerSearchDtoToRecategorisationPrisonerSearchDto = (
   currentIncentive: prisonerSearchDto.currentIncentive,
   legalStatus: prisonerSearchDto.legalStatus,
   sentenceStartDate: prisonerSearchDto.sentenceStartDate,
+  recall: prisonerSearchDto.recall,
 })


### PR DESCRIPTION
We know that some are errors due to being on remand and some are errors due to being recalls but I want to see if the recall flag or the legal status will help us differentiate between the two so we can handle them correctly.