### PR TITLE
Fix for Si 1508 open conditions kick out page bug

### DIFF
--- a/integration_tests/e2e/recat/openConditions.cy.ts
+++ b/integration_tests/e2e/recat/openConditions.cy.ts
@@ -43,13 +43,11 @@ describe('Open Conditions', () => {
     }
 
     today = new Date()
-  })
 
-  it('The happy path is correct for recategoriser setting cat D, all yeses, then cancelling open conditions', () => {
     cy.task('insertFormTableDbRow', {
       id: -1,
       bookingId: 12,
-      nomisSequenceNumber: 1,
+      // nomisSequenceNumber: 1,
       catType: CATEGORISATION_TYPE.RECAT,
       offenderNo: 'B2345YZ',
       sequenceNumber: 1,
@@ -77,13 +75,12 @@ describe('Open Conditions', () => {
       approvedBy: null,
     })
 
-    // when: 'The categoriser sets cat D'
     cy.task('stubRecategorise')
     cy.task('stubGetPrisonerSearchPrisoners')
     cy.task('stubSentenceData', {
       offenderNumbers: ['B2345XY', 'B2345YZ'],
       bookingIds: [11, 12],
-      startDates: [sentenceStartDates.B2345XY, sentenceStartDates.B2345YZ],
+      startDates: [today, today],
     })
     cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
     cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
@@ -124,7 +121,9 @@ describe('Open Conditions', () => {
       user: RECATEGORISER_USER,
     })
     cy.signIn()
+  })
 
+  it('The happy path is correct for recategoriser setting cat D, all yeses, then cancelling open conditions', () => {
     const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
     recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
 
@@ -257,7 +256,7 @@ describe('Open Conditions', () => {
         security_reviewed_date: null,
         approval_date: null,
         cat_type: 'RECAT',
-        nomis_sequence_no: 1,
+        nomis_sequence_no: null,
         assessment_date: null,
         approved_by: null,
         assessed_by: null,
@@ -414,7 +413,7 @@ describe('Open Conditions', () => {
         security_reviewed_date: null,
         approval_date: null,
         cat_type: 'RECAT',
-        nomis_sequence_no: 1,
+        nomis_sequence_no: null,
         assessment_date: null,
         approved_by: null,
         assessed_by: null,
@@ -434,85 +433,6 @@ describe('Open Conditions', () => {
   })
 
   it('The happy path is correct for recategoriser setting cat D, all nos', () => {
-    cy.task('insertFormTableDbRow', {
-      id: -1,
-      bookingId: 12,
-      // nomisSequenceNumber: 1,
-      catType: CATEGORISATION_TYPE.RECAT,
-      offenderNo: 'B2345YZ',
-      sequenceNumber: 1,
-      status: STATUS.STARTED.name,
-      prisonId: AGENCY_LOCATION.LEI.id,
-      startDate: new Date(),
-      formResponse: {
-        recat: {
-          decision: { category: 'C' },
-          oasysInput: { date: '14/12/2019', oasysRelevantInfo: 'No' },
-          securityInput: { securityInputNeeded: 'Yes', securityNoteNeeded: 'No' },
-          nextReviewDate: { date: '14/12/2019' },
-          prisonerBackground: { offenceDetails: 'offence Details text' },
-          riskAssessment: {
-            lowerCategory: 'lower security category text',
-            otherRelevant: 'Yes',
-            higherCategory: 'higher security category text',
-            otherRelevantText: 'other relevant information',
-          },
-        },
-      },
-      securityReviewedBy: null,
-      securityReviewedDate: null,
-      assignedUserId: null,
-      approvedBy: null,
-    })
-
-    // when: 'The categoriser overrides to D'
-    cy.task('stubRecategorise')
-    cy.task('stubGetPrisonerSearchPrisoners')
-    cy.task('stubSentenceData', {
-      offenderNumbers: ['B2345XY', 'B2345YZ'],
-      bookingIds: [11, 12],
-      startDates: [today, today],
-    })
-    cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
-    cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
-    cy.task('stubOffenceHistory', { offenderNumber: 'B2345YZ' })
-    cy.task('stubGetOffenderDetails', {
-      bookingId: 12,
-      offenderNo: 'B2345YZ',
-      youngOffender: false,
-      indeterminateSentence: false,
-    })
-    cy.task('stubGetSocProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      transferToSecurity: false,
-    })
-    cy.task('stubGetExtremismProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      increasedRisk: true,
-      notifyRegionalCTLead: false,
-    })
-    cy.task('stubGetEscapeProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      onEscapeList: true,
-      activeOnEscapeList: true,
-    })
-    cy.task('stubGetViolenceProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      veryHighRiskViolentOffender: true,
-      notifySafetyCustodyLead: true,
-      displayAssaults: false,
-    })
-    cy.task('stubAgencyDetails', { agency: 'LPI' })
-
-    cy.stubLogin({
-      user: RECATEGORISER_USER,
-    })
-    cy.signIn()
-
     const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
     recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
 
@@ -849,85 +769,6 @@ describe('Open Conditions', () => {
   })
 
   it('recategoriser sets D, supervisor overrides to C', () => {
-    cy.task('insertFormTableDbRow', {
-      id: -1,
-      bookingId: 12,
-      // nomisSequenceNumber: 1,
-      catType: CATEGORISATION_TYPE.RECAT,
-      offenderNo: 'B2345YZ',
-      sequenceNumber: 1,
-      status: STATUS.STARTED.name,
-      prisonId: AGENCY_LOCATION.LEI.id,
-      startDate: new Date(),
-      formResponse: {
-        recat: {
-          decision: { category: 'C' },
-          oasysInput: { date: '14/12/2019', oasysRelevantInfo: 'No' },
-          securityInput: { securityInputNeeded: 'Yes', securityNoteNeeded: 'No' },
-          nextReviewDate: { date: '14/12/2019' },
-          prisonerBackground: { offenceDetails: 'offence Details text' },
-          riskAssessment: {
-            lowerCategory: 'lower security category text',
-            otherRelevant: 'Yes',
-            higherCategory: 'higher security category text',
-            otherRelevantText: 'other relevant information',
-          },
-        },
-      },
-      securityReviewedBy: null,
-      securityReviewedDate: null,
-      assignedUserId: null,
-      approvedBy: null,
-    })
-
-    // when: 'The categoriser overrides to D'
-    cy.task('stubRecategorise')
-    cy.task('stubGetPrisonerSearchPrisoners')
-    cy.task('stubSentenceData', {
-      offenderNumbers: ['B2345XY', 'B2345YZ'],
-      bookingIds: [11, 12],
-      startDates: [today, today],
-    })
-    cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
-    cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
-    cy.task('stubOffenceHistory', { offenderNumber: 'B2345YZ' })
-    cy.task('stubGetOffenderDetails', {
-      bookingId: 12,
-      offenderNo: 'B2345YZ',
-      youngOffender: false,
-      indeterminateSentence: false,
-    })
-    cy.task('stubGetSocProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      transferToSecurity: false,
-    })
-    cy.task('stubGetExtremismProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      increasedRisk: true,
-      notifyRegionalCTLead: false,
-    })
-    cy.task('stubGetEscapeProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      onEscapeList: true,
-      activeOnEscapeList: true,
-    })
-    cy.task('stubGetViolenceProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      veryHighRiskViolentOffender: true,
-      notifySafetyCustodyLead: true,
-      displayAssaults: false,
-    })
-    cy.task('stubAgencyDetails', { agency: 'LPI' })
-
-    cy.stubLogin({
-      user: RECATEGORISER_USER,
-    })
-    cy.signIn()
-
     const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
     recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
 
@@ -1279,84 +1120,6 @@ describe('Open Conditions', () => {
   })
 
   it('The happy path is correct for supervisor overriding to D', () => {
-    cy.task('insertFormTableDbRow', {
-      id: -1,
-      bookingId: 12,
-      catType: CATEGORISATION_TYPE.RECAT,
-      offenderNo: 'B2345YZ',
-      sequenceNumber: 1,
-      status: STATUS.STARTED.name,
-      prisonId: AGENCY_LOCATION.LEI.id,
-      startDate: new Date(),
-      formResponse: {
-        recat: {
-          decision: { category: 'C' },
-          oasysInput: { date: '14/12/2019', oasysRelevantInfo: 'No' },
-          securityInput: { securityInputNeeded: 'Yes', securityNoteNeeded: 'No' },
-          nextReviewDate: { date: '14/12/2019' },
-          prisonerBackground: { offenceDetails: 'offence Details text' },
-          riskAssessment: {
-            lowerCategory: 'lower security category text',
-            otherRelevant: 'Yes',
-            higherCategory: 'higher security category text',
-            otherRelevantText: 'other relevant information',
-          },
-        },
-      },
-      securityReviewedBy: null,
-      securityReviewedDate: null,
-      assignedUserId: null,
-      approvedBy: null,
-    })
-
-    // when: 'The categoriser submits cat C'
-    cy.task('stubRecategorise')
-    cy.task('stubGetPrisonerSearchPrisoners')
-    cy.task('stubSentenceData', {
-      offenderNumbers: ['B2345XY', 'B2345YZ'],
-      bookingIds: [11, 12],
-      startDates: [today, today],
-    })
-    cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
-    cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
-    cy.task('stubOffenceHistory', { offenderNumber: 'B2345YZ' })
-    cy.task('stubGetOffenderDetails', {
-      bookingId: 12,
-      offenderNo: 'B2345YZ',
-      youngOffender: false,
-      indeterminateSentence: false,
-    })
-    cy.task('stubGetSocProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      transferToSecurity: false,
-    })
-    cy.task('stubGetExtremismProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      increasedRisk: true,
-      notifyRegionalCTLead: false,
-    })
-    cy.task('stubGetEscapeProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      onEscapeList: true,
-      activeOnEscapeList: true,
-    })
-    cy.task('stubGetViolenceProfile', {
-      offenderNo: 'B2345YZ',
-      category: 'C',
-      veryHighRiskViolentOffender: true,
-      notifySafetyCustodyLead: true,
-      displayAssaults: false,
-    })
-    cy.task('stubAgencyDetails', { agency: 'LPI' })
-
-    cy.stubLogin({
-      user: RECATEGORISER_USER,
-    })
-    cy.signIn()
-
     const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
     recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
 
@@ -1895,6 +1658,112 @@ describe('Open Conditions', () => {
     })
     approvedViewRecatPage.validateOtherSupervisorComments({
       expectedComments: 'super other info 1 + 2',
+    })
+  })
+
+  describe('Not suitable for Open Conditions', () => {
+    beforeEach(() => {
+      const recategoriserHomePage = Page.verifyOnPage(RecategoriserHomePage)
+      recategoriserHomePage.continueReviewForPrisoner(12, 'DUE')
+
+      const tasklistRecatPage = Page.verifyOnPage(TasklistRecatPage)
+      tasklistRecatPage.decisionButton().click()
+
+      // Decision page
+      const decisionPage = Page.verifyOnPage(DecisionPage)
+      decisionPage.catDOption().click()
+      decisionPage.submitButton().click()
+
+      // Open Conditions Added Page
+      const openConditionsAddedPage = Page.verifyOnPage(OpenConditionsAdded)
+      openConditionsAddedPage.returnToRecatTasklistButton(12).click()
+
+      // 'the tasklist recat page is displayed with open conditions section added'
+      tasklistRecatPage.openConditionsButton().should('exist')
+
+      // 'open conditions task is selected'
+      tasklistRecatPage.openConditionsButton().click()
+      const tprsPage = Page.verifyOnPage(TprsPage)
+
+      // 'the TPRS page is displayed'
+      tprsPage.selectTprsRadioButton('YES')
+      tprsPage.continueButton().click()
+    })
+
+    it('Shows correct message when not suitable for open conditions because of earliest release date', () => {
+      // 'the Earliest Release page is displayed'
+      const earliestReleasePage = Page.verifyOnPage(EarliestReleaseDatePage)
+      earliestReleasePage.selectEarliestReleaseDateRadioButton('YES')
+      earliestReleasePage.selectJustifyRadioButton('NO')
+      earliestReleasePage.continueButton().click()
+
+      cy.get('h1').should('contain.text', 'Not suitable for open conditions')
+      cy.contains('This person cannot be sent to open conditions because they have more than three years to their earliest release date and there are no special circumstances to warrant them moving into open conditions')
+    })
+
+    it('Shows correct message when not suitable for open conditions because of VCS', () => {
+      // 'the Earliest Release page is displayed'
+      const earliestReleasePage = Page.verifyOnPage(EarliestReleaseDatePage)
+      earliestReleasePage.selectEarliestReleaseDateRadioButton('YES')
+      earliestReleasePage.selectJustifyRadioButton('YES')
+      earliestReleasePage.setJustifyOpenConditionsTextInput('justify details text')
+      earliestReleasePage.continueButton().click()
+
+      const victimContactSchemaPage = Page.verifyOnPage(VictimContactSchemePage)
+      victimContactSchemaPage.selectVictimContactSchemeRadioButton('YES')
+      victimContactSchemaPage.selectContactedVictimLiaisonOfficerRadioButton('NO')
+      victimContactSchemaPage.continueButton().click()
+
+      cy.get('h1').should('contain.text', 'Not suitable for open conditions')
+      cy.contains('This person cannot be sent to open conditions because a victim of the crime has opted-in to the Victim Contact Scheme and the VLO has not been contacted.')
+    })
+
+    it('Shows correct message when not suitable for open conditions because of foreign national form', () => {
+      // 'the Earliest Release page is displayed'
+      const earliestReleasePage = Page.verifyOnPage(EarliestReleaseDatePage)
+      earliestReleasePage.selectEarliestReleaseDateRadioButton('YES')
+      earliestReleasePage.selectJustifyRadioButton('YES')
+      earliestReleasePage.setJustifyOpenConditionsTextInput('justify details text')
+      earliestReleasePage.continueButton().click()
+
+      const victimContactSchemaPage = Page.verifyOnPage(VictimContactSchemePage)
+      victimContactSchemaPage.selectVictimContactSchemeRadioButton('YES')
+      victimContactSchemaPage.selectContactedVictimLiaisonOfficerRadioButton('YES')
+      victimContactSchemaPage.setVictimLiaisonOfficerResponseTextInput('vlo response text')
+      victimContactSchemaPage.continueButton().click()
+
+      const foreignNationalPage = Page.verifyOnPage(ForeignNationalPage)
+      foreignNationalPage.selectForeignNationalRadioButton('YES')
+      foreignNationalPage.selectHomeOfficeImmigrationStatusRadioButton('NO')
+      foreignNationalPage.continueButton().click()
+
+      cy.get('h1').should('contain.text', 'Not suitable for open conditions')
+      cy.contains('This person cannot be sent to open conditions without a CCD3 form')
+    })
+
+    it('Shows correct message when not suitable for open conditions because of foreign national exhausted appeals', () => {
+      // 'the Earliest Release page is displayed'
+      const earliestReleasePage = Page.verifyOnPage(EarliestReleaseDatePage)
+      earliestReleasePage.selectEarliestReleaseDateRadioButton('YES')
+      earliestReleasePage.selectJustifyRadioButton('YES')
+      earliestReleasePage.setJustifyOpenConditionsTextInput('justify details text')
+      earliestReleasePage.continueButton().click()
+
+      const victimContactSchemaPage = Page.verifyOnPage(VictimContactSchemePage)
+      victimContactSchemaPage.selectVictimContactSchemeRadioButton('YES')
+      victimContactSchemaPage.selectContactedVictimLiaisonOfficerRadioButton('YES')
+      victimContactSchemaPage.setVictimLiaisonOfficerResponseTextInput('vlo response text')
+      victimContactSchemaPage.continueButton().click()
+
+      const foreignNationalPage = Page.verifyOnPage(ForeignNationalPage)
+      foreignNationalPage.selectForeignNationalRadioButton('YES')
+      foreignNationalPage.selectHomeOfficeImmigrationStatusRadioButton('YES')
+      foreignNationalPage.selectLiabilityToBeDeportedRadioButton('YES')
+      foreignNationalPage.selectExhaustedAppealRadioButton('YES')
+      foreignNationalPage.continueButton().click()
+
+      cy.get('h1').should('contain.text', 'Not suitable for open conditions')
+      cy.contains('This person cannot be sent to open conditions because they have a liability for deportation and have exhausted all appeal rights in the UK')
     })
   })
 })

--- a/test/routes/openConditions.test.js
+++ b/test/routes/openConditions.test.js
@@ -369,19 +369,19 @@ describe('open conditions', () => {
 
   test.each`
     formName                 | userInput                                                                                     | updateInfo                                                        | nextPath
-    ${'tprs'}                | ${{ tprsSelected: 'No' }}                                                                     | ${{ tprsSelected: 'No' }}                                         | ${'/form/openConditions/earliestReleaseDate/'}
-    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}                   | ${'/form/openConditions/victimContactScheme/'}
-    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}                 | ${'/form/openConditions/previousSentences/'}
-    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                        | ${'/form/openConditions/foreignNational/'}
-    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }}            | ${'/form/openConditions/victimContactScheme/'}
-    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                      | ${'/form/openConditions/sexualOffences/'}
-    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                                    | ${'/form/openConditions/riskOfHarm/'}
-    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                                          | ${'/form/openConditions/furtherCharges/'}
-    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                             | ${'/form/openConditions/riskLevels/'}
-    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                                         | ${'/tasklist/'}
-    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                           | ${'/tasklistRecat/'}
-    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                             | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }} | ${'/form/openConditions/openConditionsNotSuitable/'}
-    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                               | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}   | ${'/form/openConditions/openConditionsNotSuitable/'}
+    ${'tprs'}                | ${{ tprsSelected: 'No' }}                                                                     | ${{ tprsSelected: 'No' }}                                         | ${'/form/openConditions/earliestReleaseDate/12345'}
+    ${'earliestReleaseDate'} | ${{ catType: 'RECAT', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}          | ${{ catType: 'RECAT', threeOrMoreYears: 'No' }}                   | ${'/form/openConditions/victimContactScheme/12345'}
+    ${'earliestReleaseDate'} | ${{ catType: 'INITIAL', threeOrMoreYears: 'No', justify: 'Yes', justifyText: 'text' }}        | ${{ catType: 'INITIAL', threeOrMoreYears: 'No' }}                 | ${'/form/openConditions/previousSentences/12345'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                                                    | ${{ catType: 'RECAT', vcsOptedFor: 'No' }}                        | ${'/form/openConditions/foreignNational/12345'}
+    ${'previousSentences'}   | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No', sevenOrMoreYears: 'No' }}                | ${{ catType: 'INITIAL', releasedLastFiveYears: 'No' }}            | ${'/form/openConditions/victimContactScheme/12345'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                                                  | ${{ catType: 'INITIAL', vcsOptedFor: 'No' }}                      | ${'/form/openConditions/sexualOffences/12345'}
+    ${'foreignNational'}     | ${{ isForeignNational: 'No', dueDeported: 'Yes', formCompleted: 'Yes', exhaustedAppeal: '' }} | ${{ isForeignNational: 'No' }}                                    | ${'/form/openConditions/riskOfHarm/12345'}
+    ${'riskOfHarm'}          | ${{ seriousHarm: 'No', harmManaged: 'Yes', harmManagedText: '' }}                             | ${{ seriousHarm: 'No' }}                                          | ${'/form/openConditions/furtherCharges/12345'}
+    ${'furtherCharges'}      | ${{}}                                                                                         | ${{}}                                                             | ${'/form/openConditions/riskLevels/12345'}
+    ${'riskLevels'}          | ${{ catType: 'INITIAL' }}                                                                     | ${{ catType: 'INITIAL' }}                                         | ${'/tasklist/12345'}
+    ${'riskLevels'}          | ${{ catType: 'RECAT' }}                                                                       | ${{ catType: 'RECAT' }}                                           | ${'/tasklistRecat/12345'}
+    ${'victimContactScheme'} | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                             | ${{ catType: 'INITIAL', vcsOptedFor: 'Yes', contactedVLO: 'No' }} | ${'/form/openConditions/openConditionsNotSuitable/12345?reason=VICTIM_CONTACT_SCHEME'}
+    ${'victimContactScheme'} | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}                               | ${{ catType: 'RECAT', vcsOptedFor: 'Yes', contactedVLO: 'No' }}   | ${'/form/openConditions/openConditionsNotSuitable/12345?reason=VICTIM_CONTACT_SCHEME'}
   `('Post $formName for $userInput.catType should go to $nextPath', ({ formName, userInput, updateInfo, nextPath }) => {
     formService.getCategorisationRecord.mockResolvedValue({
       bookingId: 12,
@@ -391,7 +391,7 @@ describe('open conditions', () => {
       .post(`/${formName}/12345`)
       .send(userInput)
       .expect(302)
-      .expect('Location', `${nextPath}12345`)
+      .expect('Location', nextPath)
       .expect(() => {
         expect(formService.update).toBeCalledWith({
           bookingId: 12345,
@@ -406,12 +406,12 @@ describe('open conditions', () => {
   })
 
   test.each`
-    formName                 | userInput
-    ${'earliestReleaseDate'} | ${{ threeOrMoreYears: 'Yes', justify: 'No' }}
-    ${'previousSentences'}   | ${{ releasedLastFiveYears: 'Yes', sevenOrMoreYears: 'Yes' }}
-    ${'foreignNational'}     | ${{ formCompleted: 'No' }}
-    ${'foreignNational'}     | ${{ exhaustedAppeal: 'Yes' }}
-  `('should render openConditionsNotSuitable page for $formName', ({ formName, userInput }) => {
+    formName                 | userInput                                                    | queryParam
+    ${'earliestReleaseDate'} | ${{ threeOrMoreYears: 'Yes', justify: 'No' }}                | ${'EARLIEST_RELEASE_DATE'}
+    ${'previousSentences'}   | ${{ releasedLastFiveYears: 'Yes', sevenOrMoreYears: 'Yes' }} | ${'PREVIOUS_SENTENCES'}
+    ${'foreignNational'}     | ${{ formCompleted: 'No' }}                                   | ${'FOREIGN_NATIONAL_FORM'}
+    ${'foreignNational'}     | ${{ exhaustedAppeal: 'Yes' }}                                | ${'FOREIGN_NATIONAL_EXHAUSTED_APPEALS'}
+  `('should render openConditionsNotSuitable page for $formName', ({ formName, userInput, queryParam }) => {
     formService.getCategorisationRecord.mockResolvedValue({
       bookingId: 12,
       formObject: userInput,
@@ -420,7 +420,7 @@ describe('open conditions', () => {
       .post(`/${formName}/12345`)
       .send(userInput)
       .expect(302)
-      .expect('Location', `/form/openConditions/openConditionsNotSuitable/12345`)
+      .expect('Location', `/form/openConditions/openConditionsNotSuitable/12345?reason=${queryParam}`)
       .expect(() => {
         expect(formService.update).toBeCalledWith({
           bookingId: 12345,
@@ -495,49 +495,6 @@ describe('open conditions', () => {
       .send({ stillRefer: 'No', catType: 'RECAT' })
       .expect(302)
       .expect('Location', `/tasklistRecat/12345`)
-  })
-
-  test('open conditions not suitable should show when previous sentences page was skipped', () => {
-    formService.getCategorisationRecord.mockResolvedValue({
-      bookingId: 12,
-      formObject: {
-        ratings: { furtherCharges: { furtherCharges: 'Yes', furtherChargesText: 'old stuff' } },
-        openConditions: {
-          earliestReleaseDate: { justify: 'Yes' },
-          victimContactScheme: { contactedVLO: 'Yes' },
-          foreignNational: { exhaustedAppeal: 'Yes' },
-        },
-      },
-      catType: 'INITIAL',
-    })
-    return request(app)
-      .get('/openConditionsNotSuitable/12345')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('This person cannot be sent to open conditions')
-      })
-  })
-
-  test('open conditions not suitable should show when VCS is not yet populated', () => {
-    formService.getCategorisationRecord.mockResolvedValue({
-      bookingId: 12,
-      formObject: {
-        ratings: { furtherCharges: { furtherCharges: 'Yes', furtherChargesText: 'old stuff' } },
-        openConditions: {
-          earliestReleaseDate: { justify: 'Yes' },
-          previousSentences: { releasedLastFiveYears: 'Yes', sevenOrMoreYears: 'Yes' },
-        },
-      },
-      catType: 'INITIAL',
-    })
-    return request(app)
-      .get('/openConditionsNotSuitable/12345')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('This person cannot be sent to open conditions')
-      })
   })
 
   test('Should have D for openConditionsSuggestedCategory for male prison', () => {


### PR DESCRIPTION
The bug was introduced when another bug was fixed... the other bug was that when open conditions was cancelled from a review it was still showing in the check my answers section and would still be in SAR requests etc. Removing it from there broke this kick out page because the kick out page was still using the persisted open conditions section to decide which error message to show, I've changed it to use a query parameter instead.