### PR TITLE
Bug showing rejected categorisations in category history table

### DIFF
--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -1330,13 +1330,8 @@ module.exports = function createOffendersService(
   async function getAllApprovedCategorisationsForOffender(nomisClient, offenderNo) {
     try {
       const allCategorisation = await nomisClient.getCategoryHistory(offenderNo)
-      // remove any that don't have an approval date  - these could be pending, rejected, cancelled
-<<<<<<< Updated upstream
-      return allCategorisation.filter(c => c.approvalDate)
-=======
-      logger.info(allCategorisation)
+      // remove any that don't have an approval date or assessment status P  - these could be pending, rejected, cancelled
       return allCategorisation.filter(c => c.approvalDate && c.assessmentStatus !== 'P')
->>>>>>> Stashed changes
     } catch (error) {
       logger.error(error, 'Error during getAllApprovedCategorisationsForOffender')
       throw error

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -1331,7 +1331,12 @@ module.exports = function createOffendersService(
     try {
       const allCategorisation = await nomisClient.getCategoryHistory(offenderNo)
       // remove any that don't have an approval date  - these could be pending, rejected, cancelled
+<<<<<<< Updated upstream
       return allCategorisation.filter(c => c.approvalDate)
+=======
+      logger.info(allCategorisation)
+      return allCategorisation.filter(c => c.approvalDate && c.assessmentStatus !== 'P')
+>>>>>>> Stashed changes
     } catch (error) {
       logger.error(error, 'Error during getAllApprovedCategorisationsForOffender')
       throw error

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -2053,6 +2053,19 @@ describe('getPrisonerBackground', () => {
       assessmentAgencyId: 'BXI',
       assessmentStatus: 'A',
     },
+    // Records which are rejected by supervisors, then cancelled will have an approval
+    // date even though they were never approved, it is the date they were rejected. They
+    // should not be included.
+    {
+      bookingId: -45,
+      offenderNo: 'ABC1',
+      classificationCode: 'B',
+      classification: 'Cat B',
+      assessmentDate: '2019-04-17',
+      approvalDate: '2019-04-17',
+      assessmentAgencyId: 'BXI',
+      assessmentStatus: 'P',
+    },
   ]
 
   test('it should return a list of historical categorisations, filtering out any pending, cancelled and future categorisations, sorted by approval date', async () => {


### PR DESCRIPTION
Added in a check that assessment is not pending to function looking for only approved assessments. It was showing some rejected categorisations in the category history table because they have an evaluation date set, which then gets called approved date in prison API even though the assessment was never approved.