### PR TITLE
added in fix for when a recalled offender has a second review post recall

### DIFF
--- a/server/utils/functionalHelpers.js
+++ b/server/utils/functionalHelpers.js
@@ -18,6 +18,7 @@ module.exports = {
   isFirstVisit,
   inProgress,
   extractNextReviewDate,
+  extractAssessmentDate,
   addSocProfile,
 }
 
@@ -76,6 +77,11 @@ function inProgress(dbRecord) {
 function extractNextReviewDate(details) {
   const catRecord = details && details.assessments && details.assessments.find(a => a.assessmentCode === 'CATEGORY')
   return catRecord && catRecord.nextReviewDate
+}
+
+function extractAssessmentDate(details) {
+  const catRecord = details && details.assessments && details.assessments.find(a => a.assessmentCode === 'CATEGORY')
+  return catRecord && catRecord.assessmentDate
 }
 
 async function addSocProfile({

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -3287,6 +3287,157 @@ describe('getDueRecats', () => {
     expect(result).toEqual([null])
   })
 
+  it('should show the expected offender who is due for a second recat after being recalled', async () => {
+    nomisClient.getRecategoriseOffenders.mockResolvedValue([
+      {
+        offenderNo: 'G9285UP',
+        bookingId: 1186272,
+        firstName: 'OBININS',
+        lastName: 'KHALIAM',
+        assessmentDate: '2019-02-29',
+        approvalDate: '2017-03-28',
+        assessmentSeq: 3,
+        assessStatus: 'A',
+        category: 'D',
+        nextReviewDate: '2019-09-23',
+      },
+    ])
+    formService.getCategorisationRecords.mockResolvedValue([])
+    prisonerSearchClient.getPrisonersByBookingIds.mockResolvedValue([
+      {
+        bookingId: 1186272,
+        prisonerNumber: 'G9285UP',
+        releaseDate: '2020-12-15',
+        sentenceStartDate: '2017-04-01',
+        recall: true,
+        postRecallReleaseDate: '2019-09-01',
+      },
+    ])
+    nomisClient.getOffenderPrisonPeriods.mockResolvedValue({
+      prisonerNumber: 'G9285UP',
+      prisonPeriod: [
+        {
+          bookNumber: '47828A',
+          bookingId: 1186272,
+          entryDate: '2023-12-08T15:50:37',
+          releaseDate: '2023-12-08T16:21:24',
+          movementDates: [
+            {
+              reasonInToPrison: 'Imprisonment Without Option',
+              dateInToPrison: '2019-02-28T15:53:37',
+              inwardType: 'ADM',
+              reasonOutOfPrison: 'Wedding/Civil Ceremony',
+              dateOutOfPrison: '2019-02-28T15:53:37',
+              outwardType: 'TAP',
+              admittedIntoPrisonId: 'BMI',
+              releaseFromPrisonId: 'BSI',
+            },
+            {
+              reasonInToPrison: 'Wedding/Civil Ceremony',
+              dateInToPrison: '2019-01-01T15:54:12',
+              inwardType: 'TAP',
+              reasonOutOfPrison: 'Conditional Release (CJA91) -SH Term>1YR',
+              dateOutOfPrison: '2019-01-31T16:20:19',
+              outwardType: 'REL',
+              admittedIntoPrisonId: 'BSI',
+              releaseFromPrisonId: 'AYI',
+            },
+          ],
+        },
+        {
+          bookNumber: '47829A',
+          bookingId: 1186273,
+          entryDate: '2023-12-08T16:21:21',
+          movementDates: [
+            {
+              reasonInToPrison: 'Imprisonment Without Option',
+              dateInToPrison: '2023-12-08T16:21:21',
+              inwardType: 'ADM',
+              admittedIntoPrisonId: 'DGI',
+            },
+          ],
+          transfers: [
+            {
+              dateOutOfPrison: '2023-12-08T16:22:02',
+              dateInToPrison: '2023-12-08T16:23:32',
+              transferReason: 'Overcrowding Draft',
+              fromPrisonId: 'DGI',
+              toPrisonId: 'BLI',
+            },
+          ],
+          prisons: ['DGI', 'BLI'],
+        },
+      ],
+    })
+
+    const result = await service.getDueRecats(
+      'A1234AA',
+      {},
+      nomisClient,
+      allocationClient,
+      prisonerSearchClient,
+      null,
+      null,
+      {},
+      true,
+    )
+
+    expect(result).toEqual([
+      {
+        offenderNo: 'G9285UP',
+        bookingId: 1186272,
+        firstName: 'OBININS',
+        lastName: 'KHALIAM',
+        assessmentDate: '2019-02-29',
+        approvalDate: '2017-03-28',
+        assessmentSeq: 3,
+        assessStatus: 'A',
+        category: 'D',
+        nextReviewDate: '2019-09-23',
+        displayName: 'Khaliam, Obinins',
+        displayStatus: 'Not started',
+        reason: { name: 'DUE', value: 'Review due' },
+        nextReviewDateDisplay: '23/09/2019',
+        overdue: false,
+        overdueText: '',
+        pnomis: false,
+        buttonText: 'Start',
+        pom: 'Steve Rendell',
+      },
+    ])
+  })
+
+  it('it should not show an offender who has a release date before their next review date, AND they are not currently in review', async () => {
+    const releaseDate = '2017-09-23'
+    const nextReviewDate = '2017-10-23'
+    nomisClient.getRecategoriseOffenders.mockResolvedValue([
+      {
+        offenderNo: 'G9285UP',
+        bookingId: 1186272,
+        firstName: 'OBININS',
+        lastName: 'KHALIAM',
+        assessmentDate: '2017-03-27',
+        approvalDate: '2017-03-28',
+        assessmentSeq: 3,
+        assessStatus: 'A',
+        category: 'D',
+        nextReviewDate,
+      },
+    ])
+    formService.getCategorisationRecords.mockResolvedValue([])
+    prisonerSearchClient.getPrisonersByBookingIds.mockResolvedValue([
+      {
+        bookingId: 1186272,
+        releaseDate,
+        sentenceStartDate: '2017-04-01',
+      },
+    ])
+
+    const result = await service.getDueRecats('A1234AA', {}, nomisClient, allocationClient, prisonerSearchClient)
+
+    expect(result).toEqual([null])
+  })
+
   it('it should not show an offender who has a release date AFTER their next review date, AND they are not currently in review', async () => {
     const releaseDate = '2017-09-23'
     const nextReviewDate = '2017-10-23'


### PR DESCRIPTION
This was an oversight when first trying the recall fix - if they are recalled they should receive a recat within 10 days of the recall date but then after that it should use the next review date for any further reviews (e.g. their second review post recall should use next review date, not the recalled date as the due date)