### PR TITLE
added in fix for recall changes still sometimes showing wrong recall date in dashboard

### DIFF
--- a/server/services/recategorisation/recall/recategorisationRecallService.test.ts
+++ b/server/services/recategorisation/recall/recategorisationRecallService.test.ts
@@ -1,4 +1,4 @@
-import { getRecalledOffendersData } from './recategorisationRecallService'
+import { ADMISSION_TYPE, getRecalledOffendersData } from './recategorisationRecallService'
 import makeTestRecategorisationPrisonerSearchDto from '../prisonerSearch/recategorisationPrisonerSearch.dto.test-factory'
 
 describe('getRecalledOffendersData', () => {
@@ -9,9 +9,10 @@ describe('getRecalledOffendersData', () => {
           {
             bookingId: 123,
             movementDates: [
-              { dateInToPrison: '2024-01-10' },
-              { dateInToPrison: '2024-04-05' },
-              { dateInToPrison: '2024-03-01' },
+              { dateInToPrison: '2024-01-10', inwardType: ADMISSION_TYPE },
+              { dateInToPrison: '2024-04-05', inwardType: ADMISSION_TYPE },
+              { dateInToPrison: '2024-03-01', inwardType: ADMISSION_TYPE },
+              { dateInToPrison: '2024-05-01', inwardType: 'TAP' },
             ],
           },
         ],

--- a/server/services/recategorisation/recall/recategorisationRecallService.ts
+++ b/server/services/recategorisation/recall/recategorisationRecallService.ts
@@ -2,6 +2,8 @@ import { RecategorisationPrisonerSearchDto } from '../prisonerSearch/recategoris
 import { RecalledOffenderData } from './recalledOffenderData'
 import logger from '../../../../log'
 
+const ADMISSION_TYPE = 'ADM'
+
 const getRecalledOffenderData = async (
   offenderNumber: string,
   bookingId: number,
@@ -13,9 +15,9 @@ const getRecalledOffenderData = async (
     `recategorisationDashboardErrorInvestigation_recalls: response = ${JSON.stringify(response)}, prison period for booking ID = ${JSON.stringify(prisonPeriodForBookingId)}`,
   )
   if (prisonPeriodForBookingId) {
-    const movementDatesSortedByDateInToPrisonDesc = prisonPeriodForBookingId.movementDates.sort(
-      (a, b) => new Date(b.dateInToPrison).getTime() - new Date(a.dateInToPrison).getTime(),
-    )
+    const movementDatesSortedByDateInToPrisonDesc = prisonPeriodForBookingId.movementDates
+      .sort((a, b) => new Date(b.dateInToPrison).getTime() - new Date(a.dateInToPrison).getTime())
+      .filter(movement => movement.inwardType === ADMISSION_TYPE)
     return {
       recallDate: movementDatesSortedByDateInToPrisonDesc[0].dateInToPrison,
     }

--- a/server/services/recategorisation/recall/recategorisationRecallService.ts
+++ b/server/services/recategorisation/recall/recategorisationRecallService.ts
@@ -2,7 +2,7 @@ import { RecategorisationPrisonerSearchDto } from '../prisonerSearch/recategoris
 import { RecalledOffenderData } from './recalledOffenderData'
 import logger from '../../../../log'
 
-const ADMISSION_TYPE = 'ADM'
+export const ADMISSION_TYPE = 'ADM'
 
 const getRecalledOffenderData = async (
   offenderNumber: string,


### PR DESCRIPTION
It was getting mixed up on temporary release / admissions e.g. if the prisoner went to a dentist, added in a filter so it would ignore the temporary (TAP) inward type.