### PR TITLE
SI-1721: Remove auto-population of date in other category assessment screen

### DIFF
--- a/integration_tests/e2e/liteCategories.cy.ts
+++ b/integration_tests/e2e/liteCategories.cy.ts
@@ -76,7 +76,6 @@ describe('Lite Categories', () => {
 
       liteCategoriesPage = LiteCategoriesPage.createForBookingId(bookingId)
       liteCategoriesPage.validateWarningVisibility({ isVisible: false })
-      liteCategoriesPage.getReAssessmentDate().should('have.value', sixMonthsFromNow.format(SHORT_DATE_FORMAT))
     })
 
     it('should have the expected lite categorisation options', () => {
@@ -108,17 +107,20 @@ describe('Lite Categories', () => {
       })
 
       it('should require a re-assessment date', () => {
-        liteCategoriesPage.clearReAssessmentDate()
         liteCategoriesPage.submitButton().click()
       })
 
       it('should require a valid date for the re-assessment date string', () => {
-        liteCategoriesPage.setReAssessmentDate('INVALID')
+        liteCategoriesPage.setReAssessmentDateDay('INVALID')
+        liteCategoriesPage.setReAssessmentDateMonth('INVALID')
+        liteCategoriesPage.setReAssessmentDateYear('INVALID')
         liteCategoriesPage.submitButton().click()
       })
 
       it('should require the re-assessment date is in the future', () => {
-        liteCategoriesPage.setReAssessmentDate('21/11/2019')
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2016')
         liteCategoriesPage.submitButton().click()
       })
     })
@@ -142,6 +144,9 @@ describe('Lite Categories', () => {
       })
 
       it('should handle a valid submission', () => {
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2099')
         liteCategoriesPage.submitButton().click()
 
         LiteCategoriesConfirmedPage.createForBookingId(bookingId)
@@ -155,7 +160,7 @@ describe('Lite Categories', () => {
           expect(data.prison_id).eq('LEI')
           expect(data.assessed_by).eq('CATEGORISER_USER')
           expect(data.assessment_committee).eq('RECP')
-          expect(data.next_review_date).eq(sixMonthsFromNow.toISOString())
+          expect(data.next_review_date).eq('2099-01-12T00:00:00.000Z')
           expect(data.assessment_comment).eq('comment')
           expect(data.placement_prison_id).eq('BXI')
         })
@@ -178,6 +183,9 @@ describe('Lite Categories', () => {
       })
 
       it('should not allow a second categorisation to begin when a categorisation is already in progress', () => {
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2099')
         liteCategoriesPage.submitButton().click()
 
         LiteCategoriesConfirmedPage.createForBookingId(bookingId)
@@ -190,6 +198,9 @@ describe('Lite Categories', () => {
       })
 
       it('should not be available for a re-categorisation', () => {
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2099')
         liteCategoriesPage.submitButton().click()
 
         const liteCategoriesConfirmedPage = Page.verifyOnPage(LiteCategoriesConfirmedPage)
@@ -210,6 +221,9 @@ describe('Lite Categories', () => {
       })
 
       it('should display the expected status to the categoriser', () => {
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2099')
         liteCategoriesPage.submitButton().click()
 
         cy.visit(CategoriserHomePage.baseUrl)
@@ -236,6 +250,9 @@ describe('Lite Categories', () => {
       })
 
       it('should prevent a further submission when the submit button is clicked', () => {
+        liteCategoriesPage.setReAssessmentDateDay('12')
+        liteCategoriesPage.setReAssessmentDateMonth('01')
+        liteCategoriesPage.setReAssessmentDateYear('2099')
         liteCategoriesPage.submitButton().click()
 
         cy.visit(`/tasklist/${bookingId}`)

--- a/integration_tests/pages/liteCategories/liteCategories.ts
+++ b/integration_tests/pages/liteCategories/liteCategories.ts
@@ -15,8 +15,14 @@ const SELECTORS = {
   COMMENT: {
     INPUT: '#comment',
   },
-  REASSESSMENT_DATE: {
-    INPUT: '#nextReviewDate',
+  REASSESSMENT_DATE_DAY: {
+    INPUT: '#nextReviewDateDay',
+  },
+  REASSESSMENT_DATE_MONTH: {
+    INPUT: '#nextReviewDateMonth',
+  },
+  REASSESSMENT_DATE_YEAR: {
+    INPUT: '#nextReviewDateYear',
   },
   RECOMMENDED_PLACEMENT: {
     INPUT: '#placement',
@@ -50,9 +56,17 @@ export default class LiteCategoriesPage extends Page {
   getComment = () => cy.get(SELECTORS.COMMENT.INPUT)
   setComment = (text: string) => this.getComment().clear().type(text)
 
-  clearReAssessmentDate = () => this.getReAssessmentDate().clear()
-  getReAssessmentDate = () => cy.get(SELECTORS.REASSESSMENT_DATE.INPUT)
-  setReAssessmentDate = (text: string) => this.clearReAssessmentDate().type(text)
+  clearReAssessmentDateDay = () => this.getReAssessmentDateDay().clear()
+  getReAssessmentDateDay = () => cy.get(SELECTORS.REASSESSMENT_DATE_DAY.INPUT)
+  setReAssessmentDateDay = (text: string) => this.clearReAssessmentDateDay().type(text)
+
+  clearReAssessmentDateMonth = () => this.getReAssessmentDateMonth().clear()
+  getReAssessmentDateMonth = () => cy.get(SELECTORS.REASSESSMENT_DATE_MONTH.INPUT)
+  setReAssessmentDateMonth = (text: string) => this.clearReAssessmentDateMonth().type(text)
+
+  clearReAssessmentDateYear = () => this.getReAssessmentDateYear().clear()
+  getReAssessmentDateYear = () => cy.get(SELECTORS.REASSESSMENT_DATE_YEAR.INPUT)
+  setReAssessmentDateYear = (text: string) => this.clearReAssessmentDateYear().type(text)
 
   getRecommendedPlacement = () => cy.get(SELECTORS.RECOMMENDED_PLACEMENT.INPUT)
   setRecommendedPlacement = (text: string) => this.getRecommendedPlacement().select(text)

--- a/server/routes/liteCategories.js
+++ b/server/routes/liteCategories.js
@@ -9,6 +9,7 @@ const {
   sanitisePrisonName,
   removeLeadingZerosFromDate,
   dateConverterWithoutLeadingZeros,
+  formatDate,
 } = require('../utils/utils')
 const { handleCsrf } = require('../utils/routes')
 const validation = require('../utils/fieldValidation')
@@ -172,10 +173,12 @@ module.exports = function Index({ formService, offendersService, userService, au
     asyncMiddlewareInDatabaseTransaction(async (req, res, transactionalDbClient) => {
       const { bookingId } = req.params
       const bookingIdInt = parseInt(bookingId, 10)
-      const { category, authority, nextReviewDate, placement, comment } = req.body
+      const { category, authority, placement, comment } = req.body
       const user = await userService.getUser(res.locals)
       res.locals.user = { ...user, ...res.locals.user }
+      req.body.nextReviewDate = formatDate(req.body.nextReviewDate)
       const details = await offendersService.getOffenderDetails(res.locals, bookingIdInt)
+      const { nextReviewDate } = req.body
 
       const tomorrow = moment().add(1, 'd').format('MM/DD/YYYY')
 
@@ -185,10 +188,12 @@ module.exports = function Index({ formService, offendersService, userService, au
 
       const schema = joi.object(fieldOptions)
 
-      if (req.body.nextReviewDate) {
-        req.body.nextReviewDate = removeLeadingZerosFromDate(req.body.nextReviewDate)
+      if (nextReviewDate) {
+        req.body.nextReviewDate = removeLeadingZerosFromDate(nextReviewDate)
       }
+
       const joiErrors = schema.validate(req.body, { stripUnknown: true, abortEarly: false })
+
       const errors = validation.mapJoiErrors(joiErrors, [
         {
           nextReviewDate: {

--- a/server/routes/liteCategories.js
+++ b/server/routes/liteCategories.js
@@ -9,7 +9,7 @@ const {
   sanitisePrisonName,
   removeLeadingZerosFromDate,
   dateConverterWithoutLeadingZeros,
-  formatDate,
+  formatDateForValidation,
 } = require('../utils/utils')
 const { handleCsrf } = require('../utils/routes')
 const validation = require('../utils/fieldValidation')
@@ -176,7 +176,7 @@ module.exports = function Index({ formService, offendersService, userService, au
       const { category, authority, placement, comment } = req.body
       const user = await userService.getUser(res.locals)
       res.locals.user = { ...user, ...res.locals.user }
-      req.body.nextReviewDate = formatDate(req.body.nextReviewDate)
+      req.body.nextReviewDate = formatDateForValidation(req.body.nextReviewDate)
       const details = await offendersService.getOffenderDetails(res.locals, bookingIdInt)
       const { nextReviewDate } = req.body
 

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -217,6 +217,14 @@ const isOpenCategory = cat => {
 
 const removeLeadingZerosFromDate = date => date.replace(/^0+/, '')?.replace(/\/0/g, '/')
 
+const formatDate = date => {
+  if (!date.day || !date.month || !date.year) {
+    return ''
+  }
+
+  return `${date.day}/${date.month}/${date.year}`
+}
+
 module.exports = {
   dateConverter,
   dateConverterWithoutLeadingZeros,
@@ -253,4 +261,5 @@ module.exports = {
   // exposed for test purposes
   isBlank,
   removeLeadingZerosFromDate,
+  formatDate,
 }

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -217,9 +217,9 @@ const isOpenCategory = cat => {
 
 const removeLeadingZerosFromDate = date => date.replace(/^0+/, '')?.replace(/\/0/g, '/')
 
-const formatDate = date => {
+const formatDateForValidation = date => {
   if (!date.day || !date.month || !date.year) {
-    return ''
+    return undefined
   }
 
   return `${date.day}/${date.month}/${date.year}`
@@ -261,5 +261,5 @@ module.exports = {
   // exposed for test purposes
   isBlank,
   removeLeadingZerosFromDate,
-  formatDate,
+  formatDateForValidation,
 }

--- a/server/views/pages/liteCategories.html
+++ b/server/views/pages/liteCategories.html
@@ -4,6 +4,7 @@
 {% from "warning-text/macro.njk" import govukWarningText %}
 {% from "select/macro.njk" import govukSelect %}
 {% from "input/macro.njk" import govukInput %}
+{% from "date-input/macro.njk" import govukDateInput %}
 {% from "textarea/macro.njk" import govukTextarea %}
 {% from "button/macro.njk" import govukButton %}
 
@@ -63,42 +64,46 @@
 
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-    <div class="govuk-grid-row govuk-body-s">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-      {{ govukSelect({
-        id: 'category',
-        name: 'category',
-        label: { text: 'Category' },
-        items: cats,
-        classes: 'govuk-!-width-full',
-        value: category
-      }) }}
+        {{ govukSelect({
+          id: 'category',
+          name: 'category',
+          label: { text: 'Category' },
+          items: cats,
+          classes: 'govuk-!-width-full',
+          value: category
+        }) }}
       </div>
       <div class="govuk-grid-column-one-third">
-      {{ govukSelect({
-        id: 'authority',
-        name: 'authority',
-        label: { text: 'Authority' },
-        items: committees,
-        classes: 'govuk-!-width-full'
-      }) }}
-      </div>
-      <div class="govuk-grid-column-one-third">
-      {{ govukInput({
-        id: 'nextReviewDate',
-        name: 'nextReviewDate',
-        label: { text: 'Re-Assessment Date' },
-        errorMessage: {
-          text: 'Enter a valid date that is after today'
-        } if (errors | findError('nextReviewDate')),
-        classes: 'govuk-!-width-full',
-        value: nextReviewDate
-      }) }}
+        {{ govukSelect({
+          id: 'authority',
+          name: 'authority',
+          label: { text: 'Authority' },
+          items: committees,
+          classes: 'govuk-!-width-full'
+        }) }}
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-     {{ govukSelect({
+      {{ govukDateInput({
+        id: "nextReviewDate",
+        items: [
+            {"id": "nextReviewDateDay", label: "Day", "name": "nextReviewDate[day]", value: nextReviewDate.day, "classes": "govuk-input--width-2"},
+            {"id": "nextReviewDateMonth", label: "Month", "name": "nextReviewDate[month]", value: nextReviewDate.month, "classes": "govuk-input--width-2"},
+            {"id": "nextReviewDateYear", label: "Year", "name": "nextReviewDate[year]", value: nextReviewDate.year, "classes": "govuk-input--width-4"}
+        ],
+        fieldset: {
+            legend: {
+              text: 'Re-Assessment Date',
+              isPageHeading: false
+            }
+          },
+        errorMessage: errors | findError('nextReviewDate')
+      }) }}
+
+      {{ govukSelect({
         id: 'placement',
         name: 'placement',
         label: { text: 'Recommended Placement' },

--- a/test/routes/liteCategories.test.js
+++ b/test/routes/liteCategories.test.js
@@ -65,7 +65,6 @@ describe('assessment', () => {
   test('get form page', () => {
     formService.getCategorisationRecord.mockResolvedValue({})
     formService.getLiteCategorisation.mockResolvedValue({})
-    const sixMonths = moment().add(6, 'months').format('D/M/YYYY')
     return request(app)
       .get(`/12`)
       .expect(200)
@@ -74,15 +73,12 @@ describe('assessment', () => {
         expect(res.text).toContain('Other category assessment</h1>')
         expect(res.text).toContain('<option value="RECP">Reception</option>')
         expect(res.text).toContain('<option value="SECUR">Security</option>')
-        expect(res.text).toMatch(
-          new RegExp(
-            `<input\\s+class="govuk-input govuk-!-width-full"\\s+id="nextReviewDate"\\s+name="nextReviewDate"\\s+type="text"\\s+value="${sixMonths}"\\s*>`,
-            's',
-          ),
-        )
-
         expect(res.text).toContain('<option value="SYI">Shrewsbury (HMP)</option>')
         expect(res.text).toContain('<option value="MDI">Moorland</option>')
+
+        expect(res.text).toMatch(/<input[^>]*id="nextReviewDateDay"[^>]*>/)
+        expect(res.text).toMatch(/<input[^>]*id="nextReviewDateMonth"[^>]*>/)
+        expect(res.text).toMatch(/<input[^>]*id="nextReviewDateYear"[^>]*>/)
       })
   })
 
@@ -111,14 +107,24 @@ describe('assessment', () => {
   })
 
   test('Post form page', () => {
-    const futureDate = moment().add(5, 'months').format('D/M/YYYY')
+    const futureDate = moment().add(5, 'months')
+
+    const futureDateFormInput = {
+      day: futureDate.date().toString(),
+      month: (futureDate.month() + 1).toString(),
+      year: futureDate.year().toString(),
+    }
+
+    const expectedDate = moment().add(5, 'months').format('D/M/YYYY')
+
     const userInput = {
       category: 'R',
       authority: 'RECP',
-      nextReviewDate: futureDate,
+      nextReviewDate: futureDateFormInput,
       placement: 'SYI',
       comment: 'some text some text',
     }
+
     return request(app)
       .post(`/12345`)
       .send(userInput)
@@ -129,6 +135,7 @@ describe('assessment', () => {
           context: mockContext,
           bookingId: 12345,
           ...userInput,
+          nextReviewDate: expectedDate,
           offenderNo: 'A1000EE',
           prisonId: 'BXI',
           transactionalClient: mockTransactionalClient,

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -18,6 +18,7 @@ const {
   getNamesFromString,
   dateConverter,
   dateConverterToISO,
+  formatDate,
 } = require('../../server/utils/utils')
 
 describe('filterJsonObjectForLogging', () => {
@@ -317,5 +318,37 @@ describe('dateConverterToISO', () => {
     it("returns the literal string 'Invalid date' when given an invalid date", () => {
       expect(dateConverterToISO('01/13/2022')).toBe('Invalid date')
     })
+  })
+})
+
+describe('formatDate', () => {
+  it('should format date correctly without leading zeros', () => {
+    const input = { day: '7', month: '3', year: '2026' }
+    expect(formatDate(input)).toBe('7/3/2026')
+  })
+
+  it('should format date correctly with leading zeros', () => {
+    const input = { day: '07', month: '03', year: '2026' }
+    expect(formatDate(input)).toBe('07/03/2026')
+  })
+
+  it('should return an empty string when day is missing', () => {
+    const input = { day: '', month: '3', year: '2026' }
+    expect(formatDate(input)).toBe('')
+  })
+
+  test('should return an empty string when month is missing', () => {
+    const input = { day: '7', month: '', year: '2026' }
+    expect(formatDate(input)).toBe('')
+  })
+
+  test('should return an empty string when year is missing', () => {
+    const input = { day: '7', month: '3', year: '' }
+    expect(formatDate(input)).toBe('')
+  })
+
+  test('should return an empty string when the day, month and year are missing', () => {
+    const input = { day: '', month: '3', year: '' }
+    expect(formatDate(input)).toBe('')
   })
 })

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -18,7 +18,7 @@ const {
   getNamesFromString,
   dateConverter,
   dateConverterToISO,
-  formatDate,
+  formatDateForValidation,
 } = require('../../server/utils/utils')
 
 describe('filterJsonObjectForLogging', () => {
@@ -321,34 +321,34 @@ describe('dateConverterToISO', () => {
   })
 })
 
-describe('formatDate', () => {
+describe('formatDateForValidation', () => {
   it('should format date correctly without leading zeros', () => {
     const input = { day: '7', month: '3', year: '2026' }
-    expect(formatDate(input)).toBe('7/3/2026')
+    expect(formatDateForValidation(input)).toBe('7/3/2026')
   })
 
   it('should format date correctly with leading zeros', () => {
     const input = { day: '07', month: '03', year: '2026' }
-    expect(formatDate(input)).toBe('07/03/2026')
+    expect(formatDateForValidation(input)).toBe('07/03/2026')
   })
 
   it('should return an empty string when day is missing', () => {
     const input = { day: '', month: '3', year: '2026' }
-    expect(formatDate(input)).toBe('')
+    expect(formatDateForValidation(input)).toBe(undefined)
   })
 
   test('should return an empty string when month is missing', () => {
     const input = { day: '7', month: '', year: '2026' }
-    expect(formatDate(input)).toBe('')
+    expect(formatDateForValidation(input)).toBe(undefined)
   })
 
   test('should return an empty string when year is missing', () => {
     const input = { day: '7', month: '3', year: '' }
-    expect(formatDate(input)).toBe('')
+    expect(formatDateForValidation(input)).toBe(undefined)
   })
 
   test('should return an empty string when the day, month and year are missing', () => {
     const input = { day: '', month: '3', year: '' }
-    expect(formatDate(input)).toBe('')
+    expect(formatDateForValidation(input)).toBe(undefined)
   })
 })


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/SI/boards/1800?selectedIssue=SI-1721)

Also changes the input to use the GDS date input component and updates the validation.