### PR TITLE
Fix sentence length bug

### DIFF
--- a/server/routes/recat.js
+++ b/server/routes/recat.js
@@ -440,7 +440,7 @@ module.exports = function Index({
     }
 
     const { sentence } = await offendersService.getOffenderDetails(res.locals, bookingId)
-    const sentenceLength = formatLength(sentence?.list[0])
+    const sentenceLength = sentence?.list?.[0] ? formatLength(sentence.list[0]) : ''
 
     log.info(
       `Categoriser selecting previous oasys assessment answer: Option: ${prevOasysAssessmentAnswer}, Release Date: ${sentence?.releaseDate}, Sentence Length: ${sentenceLength}`,

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -32,8 +32,6 @@ function formatValue(value, label) {
 }
 
 const formatLength = sentenceTerms => {
-  if (!sentenceTerms) return ''
-
   if (sentenceTerms.lifeSentence) {
     return 'Life'
   }


### PR DESCRIPTION
[This line](https://github.com/ministryofjustice/offender-categorisation/blob/b1c2e9106288173d9b6a88a6570952aa9dd45f27/server/routes/recat.js#L443) in a previous PR was erroring when calling `formatLength` with no param, adds a fix to only call `formatLength` if correct param is defined