### PR TITLE
use getLatestActiveCategorisationForOffenders for security referrals

### DIFF
--- a/integration_tests/e2e/recat/securityInput.cy.ts
+++ b/integration_tests/e2e/recat/securityInput.cy.ts
@@ -35,7 +35,7 @@ describe('Security Input', () => {
       bookingIds: [12],
       startDates: [moment('2019-01-28').format('yyyy-MM-dd')],
     })
-    cy.task('stubAssessments', { offenderNumber: 'B2345YZ' })
+    cy.task('stubAssessmentsActiveOnly', { offenderNumber: 'B2345YZ' })
     cy.task('stubSentenceDataGetSingle', { offenderNumber: 'B2345YZ', formattedReleaseDate: '2014-11-23' })
     cy.task('stubOffenceHistory', { offenderNumber: 'B2345YZ' })
     cy.task('stubGetOffenderDetails', {

--- a/integration_tests/e2e/recat/womenEstate.cy.ts
+++ b/integration_tests/e2e/recat/womenEstate.cy.ts
@@ -45,6 +45,7 @@ describe("Women's estate recategorisation", () => {
       startDates: [moment('2019-01-28').format('yyyy-MM-dd')],
     })
     cy.task('stubAssessments', { offenderNumber: testOffenderNumber })
+    cy.task('stubAssessmentsActiveOnly', { offenderNumber: testOffenderNumber })
     cy.task('stubSentenceDataGetSingle', { offenderNumber: testOffenderNumber, formattedReleaseDate: '2014-11-23' })
     cy.task('stubOffenceHistory', { offenderNumber: testOffenderNumber })
     cy.task('stubGetOffenderDetailsWomen', {

--- a/integration_tests/e2e/security/securityLanding.cy.ts
+++ b/integration_tests/e2e/security/securityLanding.cy.ts
@@ -16,8 +16,8 @@ describe('Security Landing', () => {
     cy.task('deleteRowsFromSecurityReferral')
     cy.task('reset')
     cy.task('setUpDb')
-
     cy.task('getOffenderStub', { offenderNumber: testOffenderNumber })
+    cy.task('stubAssessmentsActiveOnly', { offenderNumber: testOffenderNumber })
     cy.task('stubSentenceData', {
       offenderNumbers: [testOffenderNumber],
       bookingIds: [testBookingId],

--- a/integration_tests/mockApis/elite2.ts
+++ b/integration_tests/mockApis/elite2.ts
@@ -104,6 +104,36 @@ const stubAssessments = ({
     },
   })
 
+const stubAssessmentsActiveOnly = ({
+  offenderNumber,
+  emptyResponse = false,
+  bookingId = -45,
+}: {
+  offenderNumber: string
+  emptyResponse?: boolean
+  bookingId?: number
+}): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      url: `/elite2/api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=true`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: emptyResponse
+        ? []
+        : [
+            {
+              bookingId,
+              offenderNo: offenderNumber,
+              nextReviewDate: '2012-06-07',
+              assessStatus: 'A',
+            },
+          ],
+    },
+  })
+
 const stubAssessmentsWithCurrent = ({ offenderNumber }: { offenderNumber: string }): SuperAgentRequest =>
   stubFor({
     request: {
@@ -205,6 +235,43 @@ const stubAssessmentsWomen = ({
     request: {
       method: 'GET',
       url: `/elite2/api/offender-assessments/CATEGORY?offenderNo=${offenderNo}&latestOnly=false&activeOnly=false`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: emptyResponse
+        ? []
+        : [
+            {
+              bookingId,
+              offenderNo,
+              classification: 'No Cat A',
+              assessmentCode: 'CATEGORY',
+              assessmentDescription: 'Categorisation',
+              cellSharingAlertFlag: false,
+              assessmentDate: '2012-04-04',
+              nextReviewDate: '2012-06-07',
+              approvalDate: '2012-06-08',
+              assessmentAgencyId: 'PFI',
+              assessmentStatus: 'No CAT A, Restricted',
+            },
+          ],
+    },
+  })
+
+const stubAssessmentsWomenActiveOnly = ({
+  offenderNo,
+  emptyResponse = false,
+  bookingId = -45,
+}: {
+  offenderNo: string
+  emptyResponse?: boolean
+  bookingId?: number
+}): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      url: `/elite2/api/offender-assessments/CATEGORY?offenderNo=${offenderNo}&latestOnly=true&activeOnly=true`,
     },
     response: {
       status: 200,
@@ -1686,8 +1753,10 @@ export default {
   stubAgencyDetails,
   stubAgenciesPrison,
   stubAssessments,
+  stubAssessmentsActiveOnly,
   stubAssessmentsWithCurrent,
   stubAssessmentsWomen,
+  stubAssessmentsWomenActiveOnly,
   stubCategorise,
   stubCategoriseUpdate,
   stubCategorised,

--- a/integration_tests/mockApis/elite2.ts
+++ b/integration_tests/mockApis/elite2.ts
@@ -1653,7 +1653,7 @@ const stubRecategorise = (
     stubFor({
       request: {
         method: 'POST',
-        url: `/elite2/api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=false`,
+        url: `/elite2/api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=true`,
       },
       response: {
         status: 200,

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -44,6 +44,11 @@ module.exports = context => {
       const path = `${apiUrl}api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=false`
       return nomisPost({ path, body: offenderNos })
     },
+    getLatestActiveCategorisationForOffenders(offenderNos) {
+      if (offenderNos.length === 0) return []
+      const path = `${apiUrl}api/offender-assessments/CATEGORY?latestOnly=true&activeOnly=true`
+      return nomisPost({ path, body: offenderNos })
+    },
     getRecategoriseOffenders(agencyId, cutoff) {
       const path = `${apiUrl}api/offender-assessments/category/${agencyId}?type=RECATEGORISATIONS&date=${cutoff}`
       return nomisUserGet({ path })

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -368,7 +368,7 @@ module.exports = function createOffendersService(
         const [offenderDetailsFromNomis, userDetailFromElite, nomisCatData] = await Promise.all([
           nomisClient.getOffenderDetailList(securityReferredFromDB.map(c => c.offenderNo)),
           nomisClient.getUserDetailList(securityReferredFromDB.map(c => c.securityReferredBy)),
-          nomisClient.getLatestCategorisationForOffenders(
+          nomisClient.getLatestActiveCategorisationForOffenders(
             securityReferredFromDB.filter(c => c.catType === CatType.RECAT.name).map(c => c.offenderNo),
           ),
         ])

--- a/server/services/offendersService.js
+++ b/server/services/offendersService.js
@@ -489,7 +489,7 @@ module.exports = function createOffendersService(
         const offenderNos = changesFromDB.map(c => c.offenderNo)
         const [offenderDetailsFromElite, offenderCategorisationsFromElite] = await Promise.all([
           nomisClient.getOffenderDetailList(offenderNos),
-          nomisClient.getLatestCategorisationForOffenders(offenderNos),
+          nomisClient.getLatestActiveCategorisationForOffenders(offenderNos),
         ])
 
         const decoratedResults = changesFromDB.map(o => {

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -129,6 +129,7 @@ afterEach(() => {
   nomisClient.getAgencyDetail.mockReset()
   nomisClient.getCategorisedOffenders.mockReset()
   nomisClient.getLatestCategorisationForOffenders.mockReset()
+  nomisClient.getLatestActiveCategorisationForOffenders.mockReset()
   nomisClient.updateNextReviewDate.mockReset()
   nomisClient.getBasicOffenderDetails.mockReset()
   formService.getLiteCategorisation.mockReset()
@@ -2745,7 +2746,7 @@ describe('getRiskChanges', () => {
     ]
 
     formService.getRiskChanges.mockResolvedValue(riskAlerts)
-    nomisClient.getLatestCategorisationForOffenders.mockResolvedValue(latestCategorisations)
+    nomisClient.getLatestActiveCategorisationForOffenders.mockResolvedValue(latestCategorisations)
     nomisClient.getOffenderDetailList.mockResolvedValue(offenderDetailList)
 
     const expected = [
@@ -2778,6 +2779,7 @@ describe('getRiskChanges', () => {
 
   test('No results from elite', async () => {
     nomisClient.getUncategorisedOffenders.mockResolvedValue([])
+    formService.getUnapprovedLite.mockResolvedValue([])
     const result = await service.getUnapprovedOffenders(context, 'LEI', mockTransactionalClient)
     expect(result).toHaveLength(0)
   })

--- a/test/services/offenderService.test.js
+++ b/test/services/offenderService.test.js
@@ -30,6 +30,7 @@ const nomisClient = {
   getAgencyDetail: jest.fn(),
   getCategorisedOffenders: jest.fn(),
   getLatestCategorisationForOffenders: jest.fn(),
+  getLatestActiveCategorisationForOffenders: jest.fn(),
   updateNextReviewDate: jest.fn(),
   getBasicOffenderDetails: jest.fn(),
   getIdentifiersByBookingId: jest.fn(),
@@ -1603,7 +1604,7 @@ describe('getReferredOffenders', () => {
 
     nomisClient.getOffenderDetailList.mockResolvedValue(offenderDetailList)
     nomisClient.getUserDetailList.mockResolvedValue(userDetailsList)
-    nomisClient.getLatestCategorisationForOffenders.mockResolvedValue([
+    nomisClient.getLatestActiveCategorisationForOffenders.mockResolvedValue([
       { bookingId: 135, nextReviewDate: '2020-09-20' },
       { bookingId: 137, nextReviewDate: '2020-09-30' },
       { bookingId: -99, nextReviewDate: '2011-09-30' },
@@ -1656,7 +1657,7 @@ describe('getReferredOffenders', () => {
 
     expect(formService.getSecurityReferredOffenders).toBeCalledTimes(1)
     expect(prisonerSearchClient.getPrisonersByBookingIds).toBeCalledTimes(1)
-    expect(nomisClient.getLatestCategorisationForOffenders).toBeCalledWith(['A1000AA', 'A1000AB'])
+    expect(nomisClient.getLatestActiveCategorisationForOffenders).toBeCalledWith(['A1000AA', 'A1000AB'])
     expect(result).toMatchObject(expected)
   })
 
@@ -1728,6 +1729,49 @@ describe('getReferredOffenders', () => {
     const result = await service.getReferredOffenders(context, mockTransactionalClient)
     expect(formService.getSecurityReferredOffenders).toBeCalledTimes(1)
     expect(result).toEqual([])
+  })
+
+  test('it should use latest active categorisations for recat security referrals', async () => {
+    nomisClient.getOffenderDetailList.mockResolvedValue(offenderDetailList)
+    nomisClient.getUserDetailList.mockResolvedValue(userDetailsList)
+    prisonerSearchClient.getPrisonersByBookingIds.mockResolvedValue([])
+
+    formService.getSecurityReferredOffenders.mockResolvedValue([
+      {
+        id: -7,
+        bookingId: 137,
+        offenderNo: 'A1000AB',
+        userId: 'me',
+        status: Status.SECURITY_MANUAL.name,
+        formObject: '',
+        securityReferredDate: '2019-02-04',
+        securityReferredBy: 'BMAY',
+        catType: 'RECAT',
+      },
+    ])
+
+    nomisClient.getLatestActiveCategorisationForOffenders.mockResolvedValue([
+      {
+        offenderNo: 'A1000AB',
+        bookingId: 137,
+        nextReviewDate: '2025-12-24',
+        assessStatus: 'A',
+      },
+    ])
+
+    const result = await service.getReferredOffenders(context, mockTransactionalClient)
+
+    expect(nomisClient.getLatestActiveCategorisationForOffenders).toBeCalledWith(['A1000AB'])
+    expect(nomisClient.getLatestCategorisationForOffenders).not.toBeCalled()
+
+    expect(result).toMatchObject([
+      {
+        offenderNo: 'A1000AB',
+        bookingId: 137,
+        dateRequired: '24/12/2025',
+        catTypeDisplay: 'Recat',
+      },
+    ])
   })
 })
 


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/SI/boards/1800?selectedIssue=SI-2337)

This pull request introduces a new method to fetch only the latest active categorisations for offenders, updates the offenders service to use this method for recategorisation security referrals, and ensures the corresponding tests are updated and expanded. The main goal is to improve data accuracy by filtering for active categorisations in relevant scenarios.